### PR TITLE
Fix lint-staged globs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 package.json
 node_modules
+build

--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
     }
   },
   "lint-staged": {
-    "*.{js}": [
+    "src/**/*.js": [
       "prettier --write",
       "eslint --fix",
       "git add"
     ],
-    "*.{json,css,md}": [
+    "**/*.{json,css,md}": [
       "prettier --write",
       "git add"
     ]


### PR DESCRIPTION
### Description
The globs in `package.json` for `lint-staged` needed to be modified in order to traverse the directory structure to run the pre commit tasks.