### PR TITLE
Use material ui (via ot-ui)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
 import { NavBar, Footer, OtUiThemeProvider } from 'ot-ui';
 
@@ -16,14 +16,22 @@ const App = () => (
     <OtUiThemeProvider>
         <Router>
             <React.Fragment>
-                <NavBar name='Genetics' />
+                <Switch>
+                    <Route exact path='/' component={null} />
+                    <Route path='/*' render={() => (<NavBar name='Genetics' />)} />
+                </Switch>
+                
                 <Route exact path="/" component={HomePage} />
                 <Route path="/study/:studyId" component={StudyPage} />
                 <Route path="/gene/:geneId" component={GenePage} />
                 <Route path="/variant/:variantId" component={VariantPage} />
                 <Route path="/locus" component={LocusPage} />
                 <Route path="/regional/:studyId/:variantId" component={RegionalPage} />
-                <Footer />
+                
+                <Switch>
+                    <Route exact path='/' component={null} />
+                    <Route path='/*' render={() => (<Footer />)} />
+                </Switch>
             </React.Fragment>
         </Router>
     </OtUiThemeProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
 
-import { NavBar, Footer, OtUiThemeProvider } from 'ot-ui';
+import { OtUiThemeProvider } from 'ot-ui';
 
 import './App.css';
 
@@ -16,22 +16,15 @@ const App = () => (
     <OtUiThemeProvider>
         <Router>
             <React.Fragment>
-                <Switch>
-                    <Route exact path='/' component={null} />
-                    <Route path='/*' render={() => (<NavBar name='Genetics' />)} />
-                </Switch>
-                
                 <Route exact path="/" component={HomePage} />
                 <Route path="/study/:studyId" component={StudyPage} />
                 <Route path="/gene/:geneId" component={GenePage} />
                 <Route path="/variant/:variantId" component={VariantPage} />
                 <Route path="/locus" component={LocusPage} />
-                <Route path="/regional/:studyId/:variantId" component={RegionalPage} />
-                
-                <Switch>
-                    <Route exact path='/' component={null} />
-                    <Route path='/*' render={() => (<Footer />)} />
-                </Switch>
+                <Route
+                    path="/regional/:studyId/:variantId"
+                    component={RegionalPage}
+                />
             </React.Fragment>
         </Router>
     </OtUiThemeProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ const App = () => (
     <OtUiThemeProvider>
         <Router>
             <React.Fragment>
-                <NavBar />
+                <NavBar name='Genetics' />
                 <Route exact path="/" component={HomePage} />
                 <Route path="/study/:studyId" component={StudyPage} />
                 <Route path="/gene/:geneId" component={GenePage} />

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 
+import { NavBar, Footer, OtUiThemeProvider } from 'ot-ui';
+
 import './App.css';
 
 import HomePage from './pages/HomePage';
@@ -11,16 +13,20 @@ import LocusPage from './pages/LocusPage';
 import RegionalPage from './pages/RegionalPage';
 
 const App = () => (
-    <Router>
-        <React.Fragment>
-            <Route exact path="/" component={HomePage} />
-            <Route path="/study/:studyId" component={StudyPage} />
-            <Route path="/gene/:geneId" component={GenePage} />
-            <Route path="/variant/:variantId" component={VariantPage} />
-            <Route path="/locus" component={LocusPage} />
-            <Route path="/regional/:studyId/:variantId" component={RegionalPage} />
-        </React.Fragment>
-    </Router>
+    <OtUiThemeProvider>
+        <Router>
+            <React.Fragment>
+                <NavBar />
+                <Route exact path="/" component={HomePage} />
+                <Route path="/study/:studyId" component={StudyPage} />
+                <Route path="/gene/:geneId" component={GenePage} />
+                <Route path="/variant/:variantId" component={VariantPage} />
+                <Route path="/locus" component={LocusPage} />
+                <Route path="/regional/:studyId/:variantId" component={RegionalPage} />
+                <Footer />
+            </React.Fragment>
+        </Router>
+    </OtUiThemeProvider>
 );
 
 export default App;

--- a/src/pages/BasePage.js
+++ b/src/pages/BasePage.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+
+import { Page, NavBar, Footer } from 'ot-ui';
+
+const BasePage = ({ children }) => {
+    const header = (
+        <Switch>
+            <Route exact path="/" component={null} />
+            <Route path="/*" render={() => <NavBar name="Genetics" />} />
+        </Switch>
+    );
+    const footer = (
+        <Switch>
+            <Route exact path="/" component={null} />
+            <Route path="/*" render={() => <Footer style={{ bottom: 0 }} />} />
+        </Switch>
+    );
+    return (
+        <Page header={header} footer={footer}>
+            {children}
+        </Page>
+    );
+};
+
+export default BasePage;

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 
 const GenePage = ({ match }) => (
     <div>
-        <Link to="/">HOME</Link>
         <h1>{`Gene ${match.params.geneId}`}</h1>
         <hr />
         <h2>Associated variants</h2>

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { Page } from 'ot-ui';
+import BasePage from './BasePage';
 
 const GenePage = ({ match }) => (
-    <Page>
+    <BasePage>
         <h1>{`Gene ${match.params.geneId}`}</h1>
         <h2>Associated variants</h2>
         <p>What about tissues?</p>
@@ -15,28 +15,44 @@ const GenePage = ({ match }) => (
                     <td>rsid</td>
                     <td>g2v score</td>
                     <td>g2v evidence</td>
-                    <td></td>
+                    <td />
                     <td>...more columns to come</td>
                 </tr>
             </thead>
             <tbody>
                 <tr>
-                    <td><Link to="/variant/1_100314838_C_T">1_100314838_C_T</Link></td>
+                    <td>
+                        <Link to="/variant/1_100314838_C_T">
+                            1_100314838_C_T
+                        </Link>
+                    </td>
                     <td>rs3753486</td>
                     <td>0.8</td>
                     <td>GTEx</td>
-                    <td><Link to="/locus"><button>Gecko Plot</button></Link></td>
+                    <td>
+                        <Link to="/locus">
+                            <button>Gecko Plot</button>
+                        </Link>
+                    </td>
                 </tr>
                 <tr>
-                    <td><Link to="/variant/2_107731839_A_G">2_107731839_A_G</Link></td>
+                    <td>
+                        <Link to="/variant/2_107731839_A_G">
+                            2_107731839_A_G
+                        </Link>
+                    </td>
                     <td>rs3753487</td>
                     <td>0.92</td>
                     <td>VEP</td>
-                    <td><Link to="/locus"><button>Gecko Plot</button></Link></td>
+                    <td>
+                        <Link to="/locus">
+                            <button>Gecko Plot</button>
+                        </Link>
+                    </td>
                 </tr>
             </tbody>
         </table>
-    </Page>
+    </BasePage>
 );
 
 export default GenePage;

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { PageTitle, Heading, SubHeading } from 'ot-ui';
 
 import BasePage from './BasePage';
 
 const GenePage = ({ match }) => (
   <BasePage>
-    <h1>{`Gene ${match.params.geneId}`}</h1>
-    <h2>Associated variants</h2>
-    <p>What about tissues?</p>
+    <PageTitle>{`Gene ${match.params.geneId}`}</PageTitle>
+    <hr />
+    <Heading>Associated variants</Heading>
+    <SubHeading>
+      Which variants are functionally linked to this gene?
+    </SubHeading>
     <table>
       <thead>
         <tr>

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+import { Page } from 'ot-ui';
+
 const GenePage = ({ match }) => (
-    <div>
+    <Page>
         <h1>{`Gene ${match.params.geneId}`}</h1>
-        <hr />
         <h2>Associated variants</h2>
         <p>What about tissues?</p>
         <table>
@@ -35,7 +36,7 @@ const GenePage = ({ match }) => (
                 </tr>
             </tbody>
         </table>
-    </div>
+    </Page>
 );
 
 export default GenePage;

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,15 +1,22 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+import { Page, Splash, HomeBox, Search, SearchExamples } from 'ot-ui';
+
+const EXAMPLES = [
+    {label: 'CDK6', url: '/gene/ENSG00000105810'},
+    {label: '1_100314838_C_T', url: '/variant/1_100314838_C_T'},
+    {label: 'Blood protein levels (Sun BB; 2018)', url: '/study/GCST005806'}
+]
+
 const HomePage = () => (
     <div>
-        <h1>Home</h1>
-        <hr />
-        <ul>
-            <li><Link to="/gene/ENSG0000002">example gene</Link></li>
-            <li><Link to="/variant/1_100314838_C_T">example variant</Link></li>
-            <li><Link to="/study/GCST005806">example study</Link></li>
-        </ul>
+        <Splash />
+        <HomeBox name='Genetics'>
+        <Search />
+        <SearchExamples examples={EXAMPLES} />
+        <p>This platform uses GRCh37 from the <a href='https://www.ncbi.nlm.nih.gov/grc'>Genome Reference Consortium</a></p>
+        </HomeBox>
     </div>
 );
 

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-import { Page, Splash, HomeBox, Search, SearchExamples } from 'ot-ui';
+import { Splash, HomeBox, Search, SearchExamples } from 'ot-ui';
 
 const EXAMPLES = [
     {label: 'CDK6', url: '/gene/ENSG00000105810'},

--- a/src/pages/LocusPage.js
+++ b/src/pages/LocusPage.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Gecko } from 'ot-charts';
 
+import { Page } from 'ot-ui';
+
 const LocusPage = () => (
-    <div>
+    <Page>
         <h1>Locus</h1>
         <Gecko />
-    </div>
+    </Page>
 );
 
 export default LocusPage;

--- a/src/pages/LocusPage.js
+++ b/src/pages/LocusPage.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { Gecko } from 'ot-charts';
 
 const LocusPage = () => (
     <div>
-        <Link to="/">HOME</Link>
         <h1>Locus</h1>
         <Gecko />
     </div>

--- a/src/pages/LocusPage.js
+++ b/src/pages/LocusPage.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import { Gecko } from 'ot-charts';
+import { PageTitle, Heading, SubHeading } from 'ot-ui';
 
 import BasePage from './BasePage';
 
 const LocusPage = () => (
   <BasePage>
-    <h1>Locus</h1>
+    <PageTitle>Locus</PageTitle>
+    <hr />
+    <Heading>Associations</Heading>
+    <SubHeading>What genetic evidence is there within this locus?</SubHeading>
     <Gecko />
   </BasePage>
 );

--- a/src/pages/LocusPage.js
+++ b/src/pages/LocusPage.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Gecko } from 'ot-charts';
 
-import { Page } from 'ot-ui';
+import BasePage from './BasePage';
 
 const LocusPage = () => (
-    <Page>
+    <BasePage>
         <h1>Locus</h1>
         <Gecko />
-    </Page>
+    </BasePage>
 );
 
 export default LocusPage;

--- a/src/pages/RegionalPage.js
+++ b/src/pages/RegionalPage.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { Regional } from 'ot-charts';
 
 const RegionalPage = ({ match }) => (
     <div>
-        <Link to="/">HOME</Link>
         <h1>{`Regional ${match.params.studyId}, ${match.params.variantId}`}</h1>
         <Regional />
     </div>

--- a/src/pages/RegionalPage.js
+++ b/src/pages/RegionalPage.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import { Regional } from 'ot-charts';
+import { PageTitle, Heading, SubHeading } from 'ot-ui';
 
 import BasePage from './BasePage';
 
 const RegionalPage = ({ match }) => (
   <BasePage>
-    <h1>{`Regional ${match.params.studyId}, ${match.params.variantId}`}</h1>
+    <PageTitle>{`Regional ${match.params.studyId}, ${
+      match.params.variantId
+    }`}</PageTitle>
+    <hr />
     <Regional />
   </BasePage>
 );

--- a/src/pages/RegionalPage.js
+++ b/src/pages/RegionalPage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Regional } from 'ot-charts';
-import { PageTitle, Heading, SubHeading } from 'ot-ui';
+import { PageTitle } from 'ot-ui';
 
 import BasePage from './BasePage';
 

--- a/src/pages/RegionalPage.js
+++ b/src/pages/RegionalPage.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Regional } from 'ot-charts';
 
-import { Page } from 'ot-ui';
+import BasePage from './BasePage';
 
 const RegionalPage = ({ match }) => (
-    <Page>
+    <BasePage>
         <h1>{`Regional ${match.params.studyId}, ${match.params.variantId}`}</h1>
         <Regional />
-    </Page>
+    </BasePage>
 );
 
 export default RegionalPage;

--- a/src/pages/RegionalPage.js
+++ b/src/pages/RegionalPage.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Regional } from 'ot-charts';
 
+import { Page } from 'ot-ui';
+
 const RegionalPage = ({ match }) => (
-    <div>
+    <Page>
         <h1>{`Regional ${match.params.studyId}, ${match.params.variantId}`}</h1>
         <Regional />
-    </div>
+    </Page>
 );
 
 export default RegionalPage;

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -4,6 +4,7 @@ import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
 import { Manhattan } from 'ot-charts';
+import { Page } from 'ot-ui';
 
 const manhattanQuery = gql`{
     manhattan(studyId: "GCT123") {
@@ -21,7 +22,7 @@ const manhattanQuery = gql`{
 }`;
 
 const StudyPage = ({ match }) => (
-    <div>
+    <Page>
         <h1>{`Study ${match.params.studyId}`}</h1>
         <hr />
         <h2>Associated loci</h2>
@@ -71,7 +72,7 @@ const StudyPage = ({ match }) => (
                 </tr>
             </tbody>
         </table>
-    </div>
+    </Page>
 );
 
 export default StudyPage;

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -22,7 +22,6 @@ const manhattanQuery = gql`{
 
 const StudyPage = ({ match }) => (
     <div>
-        <Link to="/">HOME</Link>
         <h1>{`Study ${match.params.studyId}`}</h1>
         <hr />
         <h2>Associated loci</h2>

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -4,36 +4,38 @@ import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
 import { Manhattan } from 'ot-charts';
-import { Page } from 'ot-ui';
 
-const manhattanQuery = gql`{
-    manhattan(studyId: "GCT123") {
-        associations {
-            indexVariantId
-            indexVariantRsId
-            pval
-            chromosome
-            position
-            credibleSetSize
-            ldSetSize
-            bestGenes
+import BasePage from './BasePage';
+
+const manhattanQuery = gql`
+    {
+        manhattan(studyId: "GCT123") {
+            associations {
+                indexVariantId
+                indexVariantRsId
+                pval
+                chromosome
+                position
+                credibleSetSize
+                ldSetSize
+                bestGenes
+            }
         }
     }
-}`;
+`;
 
 const StudyPage = ({ match }) => (
-    <Page>
+    <BasePage>
         <h1>{`Study ${match.params.studyId}`}</h1>
         <hr />
         <h2>Associated loci</h2>
-        <Query query={manhattanQuery} fetchPolicy='network-only'
-        >
+        <Query query={manhattanQuery} fetchPolicy="network-only">
             {({ loading, error, data }) => {
                 // TODO: handle more gracefully within Manhattan
                 if (data.manhattan) {
                     return <Manhattan data={data.manhattan} />;
                 } else {
-                    return <Manhattan data={{associations: []}} />;
+                    return <Manhattan data={{ associations: [] }} />;
                 }
             }}
         </Query>
@@ -53,7 +55,11 @@ const StudyPage = ({ match }) => (
             </thead>
             <tbody>
                 <tr>
-                    <td><Link to="/variant/1_100314838_C_T">1_100314838_C_T</Link></td>
+                    <td>
+                        <Link to="/variant/1_100314838_C_T">
+                            1_100314838_C_T
+                        </Link>
+                    </td>
                     <td>rs3753486</td>
                     <td>1</td>
                     <td>100314838</td>
@@ -62,7 +68,11 @@ const StudyPage = ({ match }) => (
                     <td>7</td>
                 </tr>
                 <tr>
-                    <td><Link to="/variant/2_107731839_A_G">2_107731839_A_G</Link></td>
+                    <td>
+                        <Link to="/variant/2_107731839_A_G">
+                            2_107731839_A_G
+                        </Link>
+                    </td>
                     <td>rs3753487</td>
                     <td>2</td>
                     <td>107731839</td>
@@ -72,7 +82,7 @@ const StudyPage = ({ match }) => (
                 </tr>
             </tbody>
         </table>
-    </Page>
+    </BasePage>
 );
 
 export default StudyPage;

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -4,6 +4,7 @@ import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
 import { Manhattan } from 'ot-charts';
+import { PageTitle, Heading, SubHeading } from 'ot-ui';
 
 import BasePage from './BasePage';
 
@@ -26,9 +27,10 @@ const manhattanQuery = gql`
 
 const StudyPage = ({ match }) => (
   <BasePage>
-    <h1>{`Study ${match.params.studyId}`}</h1>
+    <PageTitle>{`Study ${match.params.studyId}`}</PageTitle>
     <hr />
-    <h2>Associated loci</h2>
+    <Heading>Associated loci</Heading>
+    <SubHeading>Which loci are significantly linked to this study?</SubHeading>
     <Query query={manhattanQuery} fetchPolicy="network-only">
       {({ loading, error, data }) => {
         // TODO: handle more gracefully within Manhattan

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -20,7 +20,6 @@ const pheWASQuery = gql`{
 
 const VariantPage = ({ match }) => (
     <div>
-        <Link to="/">HOME</Link>
         <h1>{`Variant ${match.params.variantId}`}</h1>
         <hr />
         <h2>Associated genes</h2>

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -4,6 +4,7 @@ import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
 import { PheWAS } from 'ot-charts';
+import { Page } from 'ot-ui';
 
 const pheWASQuery = gql`{
     pheWAS(variantId: "1_100314838_C_T") {
@@ -19,7 +20,7 @@ const pheWASQuery = gql`{
 }`;
 
 const VariantPage = ({ match }) => (
-    <div>
+    <Page>
         <h1>{`Variant ${match.params.variantId}`}</h1>
         <hr />
         <h2>Associated genes</h2>
@@ -86,7 +87,7 @@ const VariantPage = ({ match }) => (
                 </tr>
             </tbody>
         </table>
-    </div>
+    </Page>
 );
 
 export default VariantPage;

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -4,23 +4,26 @@ import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
 import { PheWAS } from 'ot-charts';
-import { Page } from 'ot-ui';
 
-const pheWASQuery = gql`{
-    pheWAS(variantId: "1_100314838_C_T") {
-        associations {
-            studyId
-            traitReported
-            traitCode
-            pval
-            nTotal
-            nCases
+import BasePage from './BasePage';
+
+const pheWASQuery = gql`
+    {
+        pheWAS(variantId: "1_100314838_C_T") {
+            associations {
+                studyId
+                traitReported
+                traitCode
+                pval
+                nTotal
+                nCases
+            }
         }
     }
-}`;
+`;
 
 const VariantPage = ({ match }) => (
-    <Page>
+    <BasePage>
         <h1>{`Variant ${match.params.variantId}`}</h1>
         <hr />
         <h2>Associated genes</h2>
@@ -30,22 +33,34 @@ const VariantPage = ({ match }) => (
                     <td>gene</td>
                     <td>g2v score</td>
                     <td>g2v evidence</td>
-                    <td></td>
+                    <td />
                     <td>...more columns to come</td>
                 </tr>
             </thead>
             <tbody>
                 <tr>
-                    <td><Link to="/gene/ENSG0000001">CDK2</Link></td>
+                    <td>
+                        <Link to="/gene/ENSG0000001">CDK2</Link>
+                    </td>
                     <td>0.8</td>
                     <td>GTEx</td>
-                    <td><Link to="/locus"><button>Gecko Plot</button></Link></td>
+                    <td>
+                        <Link to="/locus">
+                            <button>Gecko Plot</button>
+                        </Link>
+                    </td>
                 </tr>
                 <tr>
-                    <td><Link to="/gene/ENSG0000002">CDK3</Link></td>
+                    <td>
+                        <Link to="/gene/ENSG0000002">CDK3</Link>
+                    </td>
                     <td>0.92</td>
                     <td>VEP</td>
-                    <td><Link to="/locus"><button>Gecko Plot</button></Link></td>
+                    <td>
+                        <Link to="/locus">
+                            <button>Gecko Plot</button>
+                        </Link>
+                    </td>
                 </tr>
             </tbody>
         </table>
@@ -53,11 +68,10 @@ const VariantPage = ({ match }) => (
         <h2>Associated studies</h2>
         <PheWAS />
 
-        <Query query={pheWASQuery}
-        >
+        <Query query={pheWASQuery}>
             {({ loading, error, data }) => {
-                    console.log('data', data);
-                    return null;               
+                console.log('data', data);
+                return null;
             }}
         </Query>
 
@@ -68,26 +82,38 @@ const VariantPage = ({ match }) => (
                     <td>reported trait</td>
                     <td>p-value</td>
                     <td>cases / total</td>
-                    <td></td>
+                    <td />
                     <td>...more columns to come</td>
                 </tr>
             </thead>
             <tbody>
                 <tr>
-                    <td><Link to="/study/GCST005806">GCST005806</Link></td>
+                    <td>
+                        <Link to="/study/GCST005806">GCST005806</Link>
+                    </td>
                     <td>Blood protein levels</td>
                     <td>5.3e-11</td>
-                    <td><Link to="/locus"><button>Gecko Plot</button></Link></td>
+                    <td>
+                        <Link to="/locus">
+                            <button>Gecko Plot</button>
+                        </Link>
+                    </td>
                 </tr>
                 <tr>
-                    <td><Link to="/study/GCST005831">GCST005831</Link></td>
+                    <td>
+                        <Link to="/study/GCST005831">GCST005831</Link>
+                    </td>
                     <td>Systemic lupus erythematosus</td>
                     <td>6.7e-32</td>
-                    <td><Link to="/locus"><button>Gecko Plot</button></Link></td>
+                    <td>
+                        <Link to="/locus">
+                            <button>Gecko Plot</button>
+                        </Link>
+                    </td>
                 </tr>
             </tbody>
         </table>
-    </Page>
+    </BasePage>
 );
 
 export default VariantPage;

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -4,6 +4,7 @@ import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
 import { PheWAS } from 'ot-charts';
+import { PageTitle, Heading, SubHeading } from 'ot-ui';
 
 import BasePage from './BasePage';
 
@@ -24,9 +25,12 @@ const pheWASQuery = gql`
 
 const VariantPage = ({ match }) => (
   <BasePage>
-    <h1>{`Variant ${match.params.variantId}`}</h1>
+    <PageTitle>{`Variant ${match.params.variantId}`}</PageTitle>
     <hr />
-    <h2>Associated genes</h2>
+    <Heading>Associated genes</Heading>
+    <SubHeading>
+      Which genes are functionally linked to this variant?
+    </SubHeading>
     <table>
       <thead>
         <tr>
@@ -65,7 +69,10 @@ const VariantPage = ({ match }) => (
       </tbody>
     </table>
     <hr />
-    <h2>Associated studies</h2>
+    <Heading>Associated studies</Heading>
+    <SubHeading>
+      Which studies are linked to this variant through a GWAS?
+    </SubHeading>
     <PheWAS />
 
     <Query query={pheWASQuery}>


### PR DESCRIPTION
This PR uses several components from the ot-ui which derive from Material UI components. To apply the styling overrides, the `App` contains a wrapping `OtUiThemeProvider` component.