### PR TITLE
Changes in genetics app to conform to new OtTables API

### DIFF
--- a/src/components/AssociatedIndexVariantsTable.js
+++ b/src/components/AssociatedIndexVariantsTable.js
@@ -4,6 +4,7 @@ import { OtTable, commaSeparate } from 'ot-ui';
 
 const tableColumns = [
   {
+    id: 'indexVariantId',
     label: 'indexVariantId',
     renderCell: rowData => (
       <Link to={`/variant/${rowData.indexVariantId}`}>
@@ -11,28 +12,47 @@ const tableColumns = [
       </Link>
     ),
   },
-  { label: 'indexVariantRsId', key: 'indexVariantRsId' },
+  { id: 'indexVariantRsId', label: 'indexVariantRsId' },
   {
+    id: 'studyId',
     label: 'studyId',
     renderCell: rowData => (
       <Link to={`/study/${rowData.studyId}`}>{rowData.studyId}</Link>
     ),
   },
-  { label: 'traitReported', key: 'traitReported' },
-  { label: 'pval', renderCell: rowData => rowData.pval.toPrecision(3) },
-  { label: 'pmid', key: 'pmid' },
-  { label: 'pubDate', key: 'pubDate' },
-  { label: 'pubJournal', key: 'pubJournal' },
-  // { label: 'pubTitle', key: 'pubTitle' },
-  { label: 'pubAuthor', key: 'pubAuthor' },
-  { label: 'nTotal', renderCell: rowData => commaSeparate(rowData.nTotal) },
-  { label: 'nCases', renderCell: rowData => commaSeparate(rowData.nCases) },
+  { id: 'traitReported', label: 'traitReported' },
   {
+    id: 'pval',
+    label: 'pval',
+    renderCell: rowData => rowData.pval.toPrecision(3),
+  },
+  { id: 'pmid', label: 'pmid' },
+  { id: 'pubDate', label: 'pubDate' },
+  { id: 'pubJournal', label: 'pubJournal' },
+  // { id: 'pubTitle', label: 'pubTitle' },
+  { id: 'pubAuthor', label: 'pubAuthor' },
+  {
+    id: 'nTotal',
+    label: 'nTotal',
+    renderCell: rowData => commaSeparate(rowData.nTotal),
+  },
+  {
+    id: 'nCases',
+    label: 'nCases',
+    renderCell: rowData => commaSeparate(rowData.nCases),
+  },
+  {
+    id: 'overallR2',
     label: 'overallR2',
     renderCell: rowData => rowData.overallR2.toPrecision(3),
   },
-  { label: 'log10Abf', renderCell: rowData => rowData.log10Abf.toPrecision(3) },
   {
+    id: 'log10Abf',
+    label: 'log10Abf',
+    renderCell: rowData => rowData.log10Abf.toPrecision(3),
+  },
+  {
+    id: 'posteriorProbability',
     label: 'posteriorProbability',
     renderCell: rowData => rowData.posteriorProbability.toPrecision(3),
   },

--- a/src/components/AssociatedIndexVariantsTable.js
+++ b/src/components/AssociatedIndexVariantsTable.js
@@ -59,7 +59,12 @@ const tableColumns = [
 ];
 
 const AssociatedIndexVariantsTable = ({ loading, error, data }) => (
-  <OtTable columns={tableColumns} data={data} />
+  <OtTable
+    columns={tableColumns}
+    data={data}
+    sortBy="indexVariantId"
+    order="desc"
+  />
 );
 
 export default AssociatedIndexVariantsTable;

--- a/src/components/AssociatedTagVariantsTable.js
+++ b/src/components/AssociatedTagVariantsTable.js
@@ -59,7 +59,12 @@ const tableColumns = [
 ];
 
 const AssociatedTagVariantsTable = ({ loading, error, data }) => (
-  <OtTable columns={tableColumns} data={data} />
+  <OtTable
+    columns={tableColumns}
+    data={data}
+    sortBy="tagVariantId"
+    order="desc"
+  />
 );
 
 export default AssociatedTagVariantsTable;

--- a/src/components/AssociatedTagVariantsTable.js
+++ b/src/components/AssociatedTagVariantsTable.js
@@ -4,6 +4,7 @@ import { OtTable, commaSeparate } from 'ot-ui';
 
 const tableColumns = [
   {
+    id: 'tagVariantId',
     label: 'tagVariantId',
     renderCell: rowData => (
       <Link to={`/variant/${rowData.tagVariantId}`}>
@@ -11,28 +12,47 @@ const tableColumns = [
       </Link>
     ),
   },
-  { label: 'tagVariantRsId', key: 'tagVariantRsId' },
+  { id: 'tagVariantRsId', label: 'tagVariantRsId' },
   {
+    id: 'studyId',
     label: 'studyId',
     renderCell: rowData => (
       <Link to={`/study/${rowData.studyId}`}>{rowData.studyId}</Link>
     ),
   },
-  { label: 'traitReported', key: 'traitReported' },
-  { label: 'pval', renderCell: rowData => rowData.pval.toPrecision(3) },
-  { label: 'pmid', key: 'pmid' },
-  { label: 'pubDate', key: 'pubDate' },
-  { label: 'pubJournal', key: 'pubJournal' },
-  // { label: 'pubTitle', key: 'pubTitle' },
-  { label: 'pubAuthor', key: 'pubAuthor' },
-  { label: 'nTotal', renderCell: rowData => commaSeparate(rowData.nTotal) },
-  { label: 'nCases', renderCell: rowData => commaSeparate(rowData.nCases) },
+  { id: 'traitReported', label: 'traitReported' },
   {
+    id: 'pval',
+    label: 'pval',
+    renderCell: rowData => rowData.pval.toPrecision(3),
+  },
+  { id: 'pmid', label: 'pmid' },
+  { id: 'pubDate', label: 'pubDate' },
+  { id: 'pubJournale', label: 'pubJournal' },
+  // { id: 'pubTitle', label: 'pubTitle' },
+  { id: 'pubAuthor', label: 'pubAuthor' },
+  {
+    id: 'nTotal',
+    label: 'nTotal',
+    renderCell: rowData => commaSeparate(rowData.nTotal),
+  },
+  {
+    id: 'nCases',
+    label: 'nCases',
+    renderCell: rowData => commaSeparate(rowData.nCases),
+  },
+  {
+    id: 'overallR2',
     label: 'overallR2',
     renderCell: rowData => rowData.overallR2.toPrecision(3),
   },
-  { label: 'log10Abf', renderCell: rowData => rowData.log10Abf.toPrecision(3) },
   {
+    id: 'log10Abf',
+    label: 'log10Abf',
+    renderCell: rowData => rowData.log10Abf.toPrecision(3),
+  },
+  {
+    id: 'posteriorProbability',
     label: 'posteriorProbability',
     renderCell: rowData => rowData.posteriorProbability.toPrecision(3),
   },

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -34,7 +34,14 @@ const tableColumns = [
 ];
 
 function ManhattanTable({ data }) {
-  return <OtTable columns={tableColumns} data={data} />;
+  return (
+    <OtTable
+      columns={tableColumns}
+      data={data}
+      sortBy="indexVariantId"
+      order="desc"
+    />
+  );
 }
 
 export default ManhattanTable;

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -4,6 +4,7 @@ import { OtTable, commaSeparate } from 'ot-ui';
 
 const tableColumns = [
   {
+    id: 'indexVariantId',
     label: 'indexVariantId',
     renderCell: rowData => (
       <Link to={`/variant/${rowData.indexVariantId}`}>
@@ -11,16 +12,22 @@ const tableColumns = [
       </Link>
     ),
   },
-  { label: 'indexVariantRsId', key: 'indexVariantRsId' },
   {
+    id: 'indexVariantRsId',
+    label: 'indexVariantRsId',
+  },
+  {
+    id: 'pval',
     label: 'pval',
     renderCell: rowData => rowData.pval.toPrecision(3),
   },
   {
+    id: 'credibleSetSize',
     label: 'credibleSetSize',
     renderCell: rowData => commaSeparate(rowData.credibleSetSize),
   },
   {
+    id: 'ldSetSize',
     label: 'ldSetSize',
     renderCell: rowData => commaSeparate(rowData.ldSetSize),
   },

--- a/src/components/PheWASTable.js
+++ b/src/components/PheWASTable.js
@@ -4,33 +4,40 @@ import { OtTable, commaSeparate } from 'ot-ui';
 
 const tableColumns = [
   {
+    id: 'studyId',
     label: 'studyId',
     renderCell: rowData => (
       <Link to={`/study/${rowData.studyId}`}>{rowData.studyId}</Link>
     ),
   },
   {
+    id: 'traitReported',
     label: 'traitReported',
     key: 'traitReported',
   },
   {
+    id: 'pval',
     label: 'pval',
     renderCell: rowData => rowData.pval.toPrecision(3),
   },
   {
+    id: 'nCases',
     label: 'nCases',
     renderCell: rowData => commaSeparate(rowData.nCases),
   },
   {
+    id: 'nTotal',
     label: 'nTotal',
     renderCell: rowData => commaSeparate(rowData.nTotal),
   },
   // TODO: check status of traitCode with Miguel - should we expose?
   // {
+  //   id: 'traitCode',
   //   label: 'traitCode',
   //   key: 'traitCode',
   // },
   {
+    id: 'locusView',
     label: 'Locus View',
     renderCell: () => {
       return <Link to="/locus">Gecko Plot</Link>;
@@ -39,7 +46,14 @@ const tableColumns = [
 ];
 
 function PheWASTable({ associations }) {
-  return <OtTable columns={tableColumns} data={associations} />;
+  return (
+    <OtTable
+      columns={tableColumns}
+      data={associations}
+      sortBy="studyId"
+      order="desc"
+    />
+  );
 }
 
 export default PheWASTable;

--- a/src/components/PheWASTable.js
+++ b/src/components/PheWASTable.js
@@ -13,7 +13,6 @@ const tableColumns = [
   {
     id: 'traitReported',
     label: 'traitReported',
-    key: 'traitReported',
   },
   {
     id: 'pval',
@@ -33,8 +32,7 @@ const tableColumns = [
   // TODO: check status of traitCode with Miguel - should we expose?
   // {
   //   id: 'traitCode',
-  //   label: 'traitCode',
-  //   key: 'traitCode',
+  //   label: 'traitCode'
   // },
   {
     id: 'locusView',

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';


### PR DESCRIPTION
### Description
The `OtTable` component now requires that the `columns` prop have objects with a required property named `id`. The `key` property is no longer used. Also, `OtTable` now takes two additional props called `orderBy` and `order`. `orderBy` tells `OtTable` to initially sort by a particular property and `order` tells `OtTable` if the sort is ascending (`asc`) or decreasing (`desc`).