### PR TITLE
Add version script to build and postversion script to push tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "analyse": "source-map-explorer build/static/js/main.*",
     "prettier": "prettier --write",
     "prettier:all": "prettier --write 'src/**/*.js' config-overrides.js",
-    "eslint": "eslint . --fix --ext .js"
+    "eslint": "eslint . --fix --ext .js",
+    "version": "yarn build",
+    "postversion": "git push && git push --tags"
   },
   "devDependencies": {
     "babel-plugin-import": "^1.8.0",


### PR DESCRIPTION
This PR ensures that calling `yarn version` updates the version tags on github.