### PR TITLE
Updates to Study page

### DIFF
--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -24,11 +24,14 @@ export const tableColumns = [
   {
     id: 'credibleSetSize',
     label: 'Credible Set Size',
+    tooltip: 'Number of variants in 95% credible set at this locus',
     renderCell: rowData => commaSeparate(rowData.credibleSetSize),
   },
   {
     id: 'ldSetSize',
     label: 'LD Set Size',
+    tooltip:
+      'Number of variants that are in LD (R2 >= 0.7) with this lead variant',
     renderCell: rowData => commaSeparate(rowData.ldSetSize),
   },
 ];

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -5,7 +5,7 @@ import { OtTable, commaSeparate } from 'ot-ui';
 export const tableColumns = [
   {
     id: 'indexVariantId',
-    label: 'indexVariantId',
+    label: 'Lead Variant',
     renderCell: rowData => (
       <Link to={`/variant/${rowData.indexVariantId}`}>
         {rowData.indexVariantId}
@@ -14,21 +14,21 @@ export const tableColumns = [
   },
   {
     id: 'indexVariantRsId',
-    label: 'indexVariantRsId',
+    label: 'rsID',
   },
   {
     id: 'pval',
-    label: 'pval',
+    label: 'P-value',
     renderCell: rowData => rowData.pval.toPrecision(3),
   },
   {
     id: 'credibleSetSize',
-    label: 'credibleSetSize',
+    label: 'Credible Set Size',
     renderCell: rowData => commaSeparate(rowData.credibleSetSize),
   },
   {
     id: 'ldSetSize',
-    label: 'ldSetSize',
+    label: 'LD Set Size',
     renderCell: rowData => commaSeparate(rowData.ldSetSize),
   },
 ];

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -38,12 +38,7 @@ export const tableColumns = [
 
 function ManhattanTable({ data }) {
   return (
-    <OtTable
-      columns={tableColumns}
-      data={data}
-      sortBy="indexVariantId"
-      order="desc"
-    />
+    <OtTable columns={tableColumns} data={data} sortBy="pval" order="asc" />
   );
 }
 

--- a/src/graphql-mocking/mocks.js
+++ b/src/graphql-mocking/mocks.js
@@ -132,6 +132,12 @@ const mockSearchResult = () => {
     studies: SEARCH_STUDIES,
   };
 };
+const mockStudyInfo = () => {
+  return {
+    ...SEARCH_STUDIES[0],
+    pmid: '8962668',
+  };
+};
 const mockVariantId = () => {
   const chromosome = casual.random_element(CHROMOSOMES);
   const position = casual.integer(1, CHROMOSOME_LENGTHS_GRCH38[chromosome]);
@@ -157,6 +163,7 @@ const mocks = {
     }));
     return { associations };
   },
+  StudyInfo: mockStudyInfo,
   SearchResult: mockSearchResult,
   IndexVariantAndStudyForTagVariant: () => {
     const study = casual.random_element(STUDIES);

--- a/src/graphql-mocking/schema.js
+++ b/src/graphql-mocking/schema.js
@@ -27,7 +27,8 @@ export const typeDefs = gql`
   }
   type RootQueryType {
     # search(queryString: String): [SearchResult!]!
-    manhattan(studyId: String!): Manhattan
+    studyInfo(studyId: String!): StudyInfo!
+    manhattan(studyId: String!): Manhattan!
     # regional(studyId: String!, leadVariantId: String!, chromosome: String!, start: Int!, end: Int!): Regional
     pheWAS(variantId: String!): PheWAS
     search(queryString: String!): SearchResult
@@ -100,6 +101,14 @@ export const typeDefs = gql`
   #     id: String!
   #     term: String!
   # }
+  type StudyInfo {
+    studyId: String!
+    traitReported: String!
+    pubAuthor: String
+    pubDate: String
+    pubJournal: String
+    pmid: String
+  }
   type Manhattan {
     associations: [ManhattanAssociation!]!
   }


### PR DESCRIPTION
This PR updates the Study page following the easier comments in https://github.com/opentargets/genetics/issues/53. Specifically:
* Additional publication data at top of page
* Column names and tooltips
* Default sorting by p-value ascending
