### PR TITLE
Add SVG download functionality

### DIFF
--- a/src/components/AssociatedGenesTable.js
+++ b/src/components/AssociatedGenesTable.js
@@ -9,13 +9,13 @@ const tableColumns = [
   { id: 'overallScore', label: 'Confidence' },
 ];
 
-const AssociatedGenesTable = ({ loading, error, data }) => (
+const AssociatedGenesTable = ({ loading, error, data, filenameStem }) => (
   <OtTable
     columns={tableColumns}
     data={data}
     sortBy="pval"
     order="asc"
-    downloadFileStem="assigned-genes"
+    downloadFileStem={filenameStem}
   />
 );
 

--- a/src/components/AssociatedIndexVariantsTable.js
+++ b/src/components/AssociatedIndexVariantsTable.js
@@ -72,13 +72,18 @@ const tableColumns = [
   },
 ];
 
-const AssociatedIndexVariantsTable = ({ loading, error, data }) => (
+const AssociatedIndexVariantsTable = ({
+  loading,
+  error,
+  filenameStem,
+  data,
+}) => (
   <OtTable
     columns={tableColumns}
     data={data}
     sortBy="pval"
     order="asc"
-    downloadFileStem="associated-index-variants"
+    downloadFileStem={filenameStem}
   />
 );
 

--- a/src/components/AssociatedTagVariantsTable.js
+++ b/src/components/AssociatedTagVariantsTable.js
@@ -79,13 +79,13 @@ const tableColumns = [
   },
 ];
 
-const AssociatedTagVariantsTable = ({ loading, error, data }) => (
+const AssociatedTagVariantsTable = ({ loading, error, filenameStem, data }) => (
   <OtTable
     columns={tableColumns}
     data={data}
     sortBy="pval"
     order="asc"
-    downloadFileStem="associated-tag-variants"
+    downloadFileStem={filenameStem}
   />
 );
 

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -36,14 +36,14 @@ export const tableColumns = [
   },
 ];
 
-function ManhattanTable({ data }) {
+function ManhattanTable({ data, filenameStem }) {
   return (
     <OtTable
       columns={tableColumns}
       data={data}
       sortBy="pval"
       order="asc"
-      downloadFileStem="independently-associated-loci"
+      downloadFileStem={filenameStem}
     />
   );
 }

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Helmet } from 'react-helmet';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
@@ -68,9 +68,9 @@ const StudyPage = ({ match }) => {
       <Query query={manhattanQuery} fetchPolicy="network-only">
         {({ loading, error, data }) => {
           return (
-            <React.Fragment>
+            <Fragment>
               {hasStudyInfo(data) ? (
-                <React.Fragment>
+                <Fragment>
                   <PageTitle>{data.studyInfo.traitReported}</PageTitle>
                   <SubHeading>
                     {`${data.studyInfo.pubAuthor} et al (${new Date(
@@ -88,10 +88,10 @@ const StudyPage = ({ match }) => {
                     </a>
                   </SubHeading>
                   <hr />
-                </React.Fragment>
+                </Fragment>
               ) : null}
               {hasAssociations(data) ? (
-                <React.Fragment>
+                <Fragment>
                   <Heading>Independently-associated loci</Heading>
                   <SubHeading>
                     {`Found ${significantLoci(data)} loci with genome-wide
@@ -110,9 +110,9 @@ const StudyPage = ({ match }) => {
                     data={data.manhattan.associations}
                     filenameStem={`${studyId}-independently-associated-loci`}
                   />
-                </React.Fragment>
+                </Fragment>
               ) : null}
-            </React.Fragment>
+            </Fragment>
           );
         }}
       </Query>

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
-import { PageTitle, Heading, SubHeading } from 'ot-ui';
+import { PageTitle, Heading, SubHeading, DownloadSVGPlot } from 'ot-ui';
 import { Manhattan } from 'ot-charts';
 
 import BasePage from './BasePage';
@@ -55,53 +55,65 @@ const manhattanQuery = gql`
   }
 `;
 
-const StudyPage = ({ match }) => (
-  <BasePage>
-    <Helmet>
-      <title>{match.params.studyId}</title>
-    </Helmet>
+const StudyPage = ({ match }) => {
+  let manhattanPlot = React.createRef();
 
-    <Query query={manhattanQuery} fetchPolicy="network-only">
-      {({ loading, error, data }) => {
-        return (
-          <React.Fragment>
-            {hasStudyInfo(data) ? (
-              <React.Fragment>
-                <PageTitle>{data.studyInfo.traitReported}</PageTitle>
-                <SubHeading>
-                  {`${data.studyInfo.pubAuthor} et al (${new Date(
-                    data.studyInfo.pubDate
-                  ).getFullYear()}) `}
-                  <em>{`${data.studyInfo.pubJournal} `}</em>
-                  <a
-                    href={`http://europepmc.org/abstract/med/${
-                      data.studyInfo.pmid
-                    }`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {data.studyInfo.pmid}
-                  </a>
-                </SubHeading>
-                <hr />
-              </React.Fragment>
-            ) : null}
-            {hasAssociations(data) ? (
-              <React.Fragment>
-                <Heading>Independently-associated loci</Heading>
-                <SubHeading>
-                  {`Found ${significantLoci(data)} loci with genome-wide
+  return (
+    <BasePage>
+      <Helmet>
+        <title>{match.params.studyId}</title>
+      </Helmet>
+
+      <Query query={manhattanQuery} fetchPolicy="network-only">
+        {({ loading, error, data }) => {
+          return (
+            <React.Fragment>
+              {hasStudyInfo(data) ? (
+                <React.Fragment>
+                  <PageTitle>{data.studyInfo.traitReported}</PageTitle>
+                  <SubHeading>
+                    {`${data.studyInfo.pubAuthor} et al (${new Date(
+                      data.studyInfo.pubDate
+                    ).getFullYear()}) `}
+                    <em>{`${data.studyInfo.pubJournal} `}</em>
+                    <a
+                      href={`http://europepmc.org/abstract/med/${
+                        data.studyInfo.pmid
+                      }`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {data.studyInfo.pmid}
+                    </a>
+                  </SubHeading>
+                  <hr />
+                </React.Fragment>
+              ) : null}
+              {hasAssociations(data) ? (
+                <React.Fragment>
+                  <Heading>Independently-associated loci</Heading>
+                  <SubHeading>
+                    {`Found ${significantLoci(data)} loci with genome-wide
                   significance (p-value < 5e-8)`}
-                </SubHeading>
-                <ManhattanWithTooltip data={data.manhattan} />
-                <ManhattanTable data={data.manhattan.associations} />
-              </React.Fragment>
-            ) : null}
-          </React.Fragment>
-        );
-      }}
-    </Query>
-  </BasePage>
-);
+                  </SubHeading>
+                  <DownloadSVGPlot
+                    svgContainer={manhattanPlot}
+                    filenameStem="independently-associated-loci"
+                  >
+                    <ManhattanWithTooltip
+                      data={data.manhattan}
+                      ref={manhattanPlot}
+                    />
+                  </DownloadSVGPlot>
+                  <ManhattanTable data={data.manhattan.associations} />
+                </React.Fragment>
+              ) : null}
+            </React.Fragment>
+          );
+        }}
+      </Query>
+    </BasePage>
+  );
+};
 
 export default StudyPage;

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -57,11 +57,12 @@ const manhattanQuery = gql`
 
 const StudyPage = ({ match }) => {
   let manhattanPlot = React.createRef();
+  const { studyId } = match.params;
 
   return (
     <BasePage>
       <Helmet>
-        <title>{match.params.studyId}</title>
+        <title>{studyId}</title>
       </Helmet>
 
       <Query query={manhattanQuery} fetchPolicy="network-only">
@@ -98,14 +99,17 @@ const StudyPage = ({ match }) => {
                   </SubHeading>
                   <DownloadSVGPlot
                     svgContainer={manhattanPlot}
-                    filenameStem="independently-associated-loci"
+                    filenameStem={`${studyId}-independently-associated-loci`}
                   >
                     <ManhattanWithTooltip
                       data={data.manhattan}
                       ref={manhattanPlot}
                     />
                   </DownloadSVGPlot>
-                  <ManhattanTable data={data.manhattan.associations} />
+                  <ManhattanTable
+                    data={data.manhattan.associations}
+                    filenameStem={`${studyId}-independently-associated-loci`}
+                  />
                 </React.Fragment>
               ) : null}
             </React.Fragment>

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -133,11 +133,12 @@ const associatedTagsQuery = gql`
 
 const VariantPage = ({ match }) => {
   let pheWASPlot = React.createRef();
+  const { variantId } = match.params;
 
   return (
     <BasePage>
       <Helmet>
-        <title>{match.params.variantId}</title>
+        <title>{variantId}</title>
       </Helmet>
       <PageTitle>{`Variant ${match.params.variantId}`}</PageTitle>
       <hr />
@@ -148,7 +149,10 @@ const VariantPage = ({ match }) => {
       <Query query={associatedGenesQuery}>
         {({ loading, error, data }) => {
           return hasAssociatedGenes(data) ? (
-            <AssociatedGenesTable data={data.genesForVariant.genes} />
+            <AssociatedGenesTable
+              data={data.genesForVariant.genes}
+              filenameStem={`${variantId}-assigned-genes`}
+            />
           ) : null;
         }}
       </Query>
@@ -163,7 +167,7 @@ const VariantPage = ({ match }) => {
             <Fragment>
               <DownloadSVGPlot
                 svgContainer={pheWASPlot}
-                filenameStem="associated-studies"
+                filenameStem={`${variantId}-traits`}
               >
                 <PheWASWithTooltip
                   associations={data.pheWAS.associations}
@@ -185,6 +189,7 @@ const VariantPage = ({ match }) => {
           return hasAssociatedIndexVariants(data) ? (
             <AssociatedIndexVariantsTable
               data={data.indexVariantsAndStudiesForTagVariant.rows}
+              filenameStem={`${variantId}-lead-variants`}
             />
           ) : null;
         }}
@@ -199,6 +204,7 @@ const VariantPage = ({ match }) => {
           return hasAssociatedTagVariants(data) ? (
             <AssociatedTagVariantsTable
               data={data.tagVariantsAndStudiesForIndexVariant.rows}
+              filenameStem={`${variantId}-tag-variants`}
             />
           ) : null;
         }}

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
-import { PageTitle, Heading, SubHeading } from 'ot-ui';
+import { PageTitle, Heading, SubHeading, DownloadSVGPlot } from 'ot-ui';
 import { PheWAS } from 'ot-charts';
 
 import BasePage from './BasePage';
@@ -131,68 +131,80 @@ const associatedTagsQuery = gql`
   }
 `;
 
-const VariantPage = ({ match }) => (
-  <BasePage>
-    <Helmet>
-      <title>{match.params.variantId}</title>
-    </Helmet>
-    <PageTitle>{`Variant ${match.params.variantId}`}</PageTitle>
-    <hr />
-    <Heading>Assigned genes</Heading>
-    <SubHeading>
-      Which genes are functionally implicated by this variant?
-    </SubHeading>
-    <Query query={associatedGenesQuery}>
-      {({ loading, error, data }) => {
-        return hasAssociatedGenes(data) ? (
-          <AssociatedGenesTable data={data.genesForVariant.genes} />
-        ) : null;
-      }}
-    </Query>
-    <hr />
-    <Heading>PheWAS</Heading>
-    <SubHeading>
-      Which traits are associated with this variant in UK Biobank?
-    </SubHeading>
-    <Query query={pheWASQuery}>
-      {({ loading, error, data }) => {
-        return hasAssociations(data) ? (
-          <Fragment>
-            <PheWASWithTooltip associations={data.pheWAS.associations} />
-            <PheWASTable associations={data.pheWAS.associations} />
-          </Fragment>
-        ) : null;
-      }}
-    </Query>
-    <hr />
-    <Heading>GWAS lead variants</Heading>
-    <SubHeading>
-      Which GWAS lead variants are linked with this variant?
-    </SubHeading>
-    <Query query={associatedIndexesQuery}>
-      {({ loading, error, data }) => {
-        return hasAssociatedIndexVariants(data) ? (
-          <AssociatedIndexVariantsTable
-            data={data.indexVariantsAndStudiesForTagVariant.rows}
-          />
-        ) : null;
-      }}
-    </Query>
-    <hr />
-    <Heading>Tag variants</Heading>
-    <SubHeading>
-      Which variants tag (through LD or finemapping) this lead variant?
-    </SubHeading>
-    <Query query={associatedTagsQuery}>
-      {({ loading, error, data }) => {
-        return hasAssociatedTagVariants(data) ? (
-          <AssociatedTagVariantsTable
-            data={data.tagVariantsAndStudiesForIndexVariant.rows}
-          />
-        ) : null;
-      }}
-    </Query>
-  </BasePage>
-);
+const VariantPage = ({ match }) => {
+  let pheWASPlot = React.createRef();
+
+  return (
+    <BasePage>
+      <Helmet>
+        <title>{match.params.variantId}</title>
+      </Helmet>
+      <PageTitle>{`Variant ${match.params.variantId}`}</PageTitle>
+      <hr />
+      <Heading>Assigned genes</Heading>
+      <SubHeading>
+        Which genes are functionally implicated by this variant?
+      </SubHeading>
+      <Query query={associatedGenesQuery}>
+        {({ loading, error, data }) => {
+          return hasAssociatedGenes(data) ? (
+            <AssociatedGenesTable data={data.genesForVariant.genes} />
+          ) : null;
+        }}
+      </Query>
+      <hr />
+      <Heading>PheWAS</Heading>
+      <SubHeading>
+        Which traits are associated with this variant in UK Biobank?
+      </SubHeading>
+      <Query query={pheWASQuery}>
+        {({ loading, error, data }) => {
+          return hasAssociations(data) ? (
+            <Fragment>
+              <DownloadSVGPlot
+                svgContainer={pheWASPlot}
+                filenameStem="associated-studies"
+              >
+                <PheWASWithTooltip
+                  associations={data.pheWAS.associations}
+                  ref={pheWASPlot}
+                />
+              </DownloadSVGPlot>
+              <PheWASTable associations={data.pheWAS.associations} />
+            </Fragment>
+          ) : null;
+        }}
+      </Query>
+      <hr />
+      <Heading>GWAS lead variants</Heading>
+      <SubHeading>
+        Which GWAS lead variants are linked with this variant?
+      </SubHeading>
+      <Query query={associatedIndexesQuery}>
+        {({ loading, error, data }) => {
+          return hasAssociatedIndexVariants(data) ? (
+            <AssociatedIndexVariantsTable
+              data={data.indexVariantsAndStudiesForTagVariant.rows}
+            />
+          ) : null;
+        }}
+      </Query>
+      <hr />
+      <Heading>Tag variants</Heading>
+      <SubHeading>
+        Which variants tag (through LD or finemapping) this lead variant?
+      </SubHeading>
+      <Query query={associatedTagsQuery}>
+        {({ loading, error, data }) => {
+          return hasAssociatedTagVariants(data) ? (
+            <AssociatedTagVariantsTable
+              data={data.tagVariantsAndStudiesForIndexVariant.rows}
+            />
+          ) : null;
+        }}
+      </Query>
+    </BasePage>
+  );
+};
 
 export default VariantPage;


### PR DESCRIPTION
This PR:
- adds SVG download functionality by using the `DownloadSVGPlot` component that lives in `ot-ui`
- renames the download file names by prepending the appropriated ids to the filenames