### PR TITLE
Connect to real data through GraphQL API for Manhattan plot

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "apollo-boost": "^0.1.10",
     "apollo-cache-inmemory": "^1.2.5",
     "apollo-client": "^2.3.5",
+    "apollo-link": "^1.2.2",
+    "apollo-link-http": "^1.5.4",
     "apollo-link-schema": "^1.1.0",
     "casual-browserify": "^1.5.19-2",
     "d3": "^5.5.0",

--- a/src/graphql-mocking/mockSchemaLink.js
+++ b/src/graphql-mocking/mockSchemaLink.js
@@ -1,16 +1,48 @@
-import { makeExecutableSchema, addMockFunctionsToSchema } from 'graphql-tools';
+import {
+  mergeSchemas,
+  makeExecutableSchema,
+  makeRemoteExecutableSchema,
+  introspectSchema,
+  addMockFunctionsToSchema,
+} from 'graphql-tools';
 import { SchemaLink } from 'apollo-link-schema';
+import { HttpLink } from 'apollo-link-http';
 
 import mocks from './mocks';
 import { typeDefs, typeResolvers } from './schema.js';
 
-// construct schema and attach type resolvers (if any)
-const schema = makeExecutableSchema({ typeDefs, resolvers: typeResolvers });
+// see https://github.com/hasura/client-side-graphql
+// see https://github.com/apollographql/graphql-tools/pull/382
+const getRemoteExecutableSchema = async uri => {
+  const httpLink = new HttpLink({ uri });
+  const remoteSchema = await introspectSchema(httpLink);
+  return makeRemoteExecutableSchema({ schema: remoteSchema, link: httpLink });
+};
 
-// attach mock resolvers
-addMockFunctionsToSchema({ schema, mocks });
+const getMergedSchemaLink = async () => {
+  // --- MOCK SCHEMA ---
+  // construct schema and attach type resolvers (if any)
+  const mockSchema = makeExecutableSchema({
+    typeDefs,
+    resolvers: typeResolvers,
+  });
 
-// construct link for client
-const mockSchemaLink = new SchemaLink({ schema });
+  // attach mock resolvers
+  addMockFunctionsToSchema({
+    schema: mockSchema,
+    mocks,
+  });
 
-export default mockSchemaLink;
+  // --- LIVE SCHEMA ---
+  const liveUrl = 'https://open-targets-genetics.appspot.com/graphql';
+  const liveSchema = await getRemoteExecutableSchema(liveUrl);
+
+  // --- MERGED SCHEMA ---
+  const mergedSchema = mergeSchemas({
+    schemas: [mockSchema, liveSchema],
+  });
+  const mergedSchemaLink = new SchemaLink({ schema: mergedSchema });
+  return mergedSchemaLink;
+};
+
+export default getMergedSchemaLink;

--- a/src/graphql-mocking/mockSchemaLink.js
+++ b/src/graphql-mocking/mockSchemaLink.js
@@ -39,7 +39,7 @@ const getMergedSchemaLink = async () => {
 
   // --- MERGED SCHEMA ---
   const mergedSchema = mergeSchemas({
-    schemas: [mockSchema, liveSchema],
+    schemas: [liveSchema, mockSchema],
   });
   const mergedSchemaLink = new SchemaLink({ schema: mergedSchema });
   return mergedSchemaLink;

--- a/src/graphql-mocking/schema.js
+++ b/src/graphql-mocking/schema.js
@@ -27,7 +27,7 @@ export const typeDefs = gql`
   }
   type RootQueryType {
     # search(queryString: String): [SearchResult!]!
-    studyInfo(studyId: String!): StudyInfo!
+    # studyInfo(studyId: String!): StudyInfo!
     # manhattan(studyId: String!): Manhattan!
     # regional(studyId: String!, leadVariantId: String!, chromosome: String!, start: Int!, end: Int!): Regional
     genesForVariant(variantId: String!): GenesForVariant!

--- a/src/graphql-mocking/schema.js
+++ b/src/graphql-mocking/schema.js
@@ -28,7 +28,7 @@ export const typeDefs = gql`
   type RootQueryType {
     # search(queryString: String): [SearchResult!]!
     studyInfo(studyId: String!): StudyInfo!
-    manhattan(studyId: String!): Manhattan!
+    # manhattan(studyId: String!): Manhattan!
     # regional(studyId: String!, leadVariantId: String!, chromosome: String!, start: Int!, end: Int!): Regional
     genesForVariant(variantId: String!): GenesForVariant!
     pheWAS(variantId: String!): PheWAS
@@ -124,28 +124,30 @@ export const typeDefs = gql`
     pubJournal: String
     pmid: String
   }
-  type Manhattan {
-    associations: [ManhattanAssociation!]!
-  }
-  type ManhattanAssociation {
-    indexVariantId: String!
-    indexVariantRsId: String
-    pval: Float!
-    chromosome: String!
-    position: Int!
-    bestGenes: [Gene!]
+  # type Manhattan {
+  #   associations: [ManhattanAssociation!]!
+  # }
+  # type ManhattanAssociation {
+  #   # indexVariantId: String!
+  #   # indexVariantRsId: String
+  #   variantId: String!
+  #   variantRsId: String
+  #   pval: Float!
+  #   chromosome: String!
+  #   position: Int!
+  #   # bestGenes: [Gene!]
 
-    # could have index variant which has no tag variants (goes nowhere on click)
-    credibleSetSize: Int
-    ldSetSize: Int
+  #   # could have index variant which has no tag variants (goes nowhere on click)
+  #   credibleSetSize: Int
+  #   ldSetSize: Int
 
-    # TODO: get this
-    # maf: Float
-  }
-  type Gene {
-    id: String
-    symbol: String
-  }
+  #   # TODO: get this
+  #   # maf: Float
+  # }
+  # type Gene {
+  #   id: String
+  #   symbol: String
+  # }
   type IndexVariantsAndStudiesForTagVariant {
     rows: [IndexVariantAndStudyForTagVariant!]!
   }

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,9 @@ getMockSchemaLink().then(mockSchemaLink => {
 // // START: WITH_LIVE_ONLY
 // import { HttpLink } from 'apollo-link-http';
 // const client = new ApolloClient({
-//   link: new HttpLink('https://open-targets-genetics.appspot.com/graphql'),
+//   link: new HttpLink({
+//     uri: 'https://open-targets-genetics.appspot.com/graphql',
+//   }),
 //   cache: new InMemoryCache(),
 // });
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,22 +7,41 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 import App from './App';
 import { unregister } from './registerServiceWorker';
 
-// Note: mock schema used for development purposes,
-//       this will be replaced before launch
-import mockSchemaLink from './graphql-mocking/mockSchemaLink';
+// START: WITH_PARTIAL_MOCKING
+import getMockSchemaLink from './graphql-mocking/mockSchemaLink';
 
-const client = new ApolloClient({
-  // uri: 'https://<API>/graphql', // TODO: connect to Miguel's API
-  link: mockSchemaLink,
-  cache: new InMemoryCache(),
+getMockSchemaLink().then(mockSchemaLink => {
+  const client = new ApolloClient({
+    link: mockSchemaLink,
+    cache: new InMemoryCache(),
+  });
+
+  ReactDOM.render(
+    <ApolloProvider client={client}>
+      <App />
+    </ApolloProvider>,
+    document.getElementById('root')
+  );
+
+  // disable service worker
+  unregister();
 });
+// END: WITH_PARTIAL_MOCKING
 
-ReactDOM.render(
-  <ApolloProvider client={client}>
-    <App />
-  </ApolloProvider>,
-  document.getElementById('root')
-);
+// // START: WITH_LIVE_ONLY
+// import { HttpLink } from 'apollo-link-http';
+// const client = new ApolloClient({
+//   link: new HttpLink('https://open-targets-genetics.appspot.com/graphql'),
+//   cache: new InMemoryCache(),
+// });
 
-// disable service worker
-unregister();
+// ReactDOM.render(
+//   <ApolloProvider client={client}>
+//     <App />
+//   </ApolloProvider>,
+//   document.getElementById('root')
+// );
+
+// // disable service worker
+// unregister();
+// // END: WITH_LIVE_ONLY

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,7 +376,7 @@ apollo-link-http-common@^0.2.4:
   dependencies:
     apollo-link "^1.2.2"
 
-apollo-link-http@^1.3.1:
+apollo-link-http@^1.3.1, apollo-link-http@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.4.tgz#b80b7b4b342c655b6a5614624b076a36be368f43"
   dependencies:


### PR DESCRIPTION
This PR updates the Apollo client to use a combination of mocked schema and the live schema from `genetics-api`. Specifically, the `manhattan` query and `studyInfo` query now call the live server (all data on the study page), while all other queries continue to use mocked data.