### PR TITLE
Render best genes in Manhattan table

### DIFF
--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -34,6 +34,21 @@ export const tableColumns = [
       'Number of variants that are in LD (R2 >= 0.7) with this lead variant',
     renderCell: rowData => commaSeparate(rowData.ldSetSize),
   },
+  {
+    id: 'bestGenes',
+    label: 'Best Genes',
+    tooltip:
+      'The list of genes with equal best overall score across all variants in either the credible set or LD expansion of a given locus',
+    renderCell: rowData => (
+      <React.Fragment>
+        {rowData.bestGenes.map((d, i) => (
+          <React.Fragment key={i}>
+            <Link to={`/gene/${d.gene.id}`}>{d.gene.symbol}</Link>{' '}
+          </React.Fragment>
+        ))}
+      </React.Fragment>
+    ),
+  },
 ];
 
 function ManhattanTable({ data, filenameStem }) {

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -62,7 +62,13 @@ const manhattanQuery = gql`
         position
         credibleSetSize
         ldSetSize
-        # bestGenes
+        bestGenes {
+          score
+          gene {
+            id
+            symbol
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR requests the `bestGenes` field from the API (recently added) and renders in the Manhattan table. See https://github.com/opentargets/genetics/issues/79.