### PR TITLE
Use live API data in associated variant tables

### DIFF
--- a/src/components/AssociatedIndexVariantsTable.js
+++ b/src/components/AssociatedIndexVariantsTable.js
@@ -58,18 +58,9 @@ const tableColumns = [
       rowData.overallR2 ? rowData.overallR2.toPrecision(3) : 'No information',
   },
   {
-    id: 'isInCredibleSet',
+    id: 'posteriorProbability',
     label: 'Is in 95% Credible Set',
-    renderCell: rowData => {
-      switch (rowData.isInCredibleSet) {
-        case true:
-          return 'True';
-        case false:
-          return 'False';
-        default:
-          return 'No information';
-      }
-    },
+    renderCell: rowData => (rowData.posteriorProbability ? 'True' : 'False'),
   },
 ];
 

--- a/src/components/AssociatedIndexVariantsTable.js
+++ b/src/components/AssociatedIndexVariantsTable.js
@@ -54,7 +54,8 @@ const tableColumns = [
     id: 'overallR2',
     label: 'LD (R-squared)',
     tooltip: 'Linkage disequilibrium with the queried variant',
-    renderCell: rowData => rowData.overallR2.toPrecision(3),
+    renderCell: rowData =>
+      rowData.overallR2 ? rowData.overallR2.toPrecision(3) : 'No information',
   },
   {
     id: 'isInCredibleSet',

--- a/src/components/AssociatedTagVariantsTable.js
+++ b/src/components/AssociatedTagVariantsTable.js
@@ -54,7 +54,8 @@ const tableColumns = [
     id: 'overallR2',
     label: 'LD (R-squared)',
     tooltip: 'Linkage disequilibrium with the queried variant',
-    renderCell: rowData => rowData.overallR2.toPrecision(3),
+    renderCell: rowData =>
+      rowData.overallR2 ? rowData.overallR2.toPrecision(3) : 'No information',
   },
   {
     id: 'isInCredibleSet',
@@ -75,7 +76,10 @@ const tableColumns = [
     label: 'posteriorProbability',
     tooltip:
       'Posterior probability from finemapping that this tag variant is causal',
-    renderCell: rowData => rowData.posteriorProbability.toPrecision(3),
+    renderCell: rowData =>
+      rowData.posteriorProbability
+        ? rowData.posteriorProbability.toPrecision(3)
+        : 'No information',
   },
 ];
 

--- a/src/components/AssociatedTagVariantsTable.js
+++ b/src/components/AssociatedTagVariantsTable.js
@@ -58,20 +58,6 @@ const tableColumns = [
       rowData.overallR2 ? rowData.overallR2.toPrecision(3) : 'No information',
   },
   {
-    id: 'isInCredibleSet',
-    label: 'Is in 95% Credible Set',
-    renderCell: rowData => {
-      switch (rowData.isInCredibleSet) {
-        case true:
-          return 'True';
-        case false:
-          return 'False';
-        default:
-          return 'No information';
-      }
-    },
-  },
-  {
     id: 'posteriorProbability',
     label: 'posteriorProbability',
     tooltip:

--- a/src/graphql-mocking/schema.js
+++ b/src/graphql-mocking/schema.js
@@ -33,12 +33,12 @@ export const typeDefs = gql`
     genesForVariant(variantId: String!): GenesForVariant!
     pheWAS(variantId: String!): PheWAS
     search(queryString: String!): SearchResult
-    indexVariantsAndStudiesForTagVariant(
-      variantId: String!
-    ): IndexVariantsAndStudiesForTagVariant
-    tagVariantsAndStudiesForIndexVariant(
-      variantId: String!
-    ): TagVariantsAndStudiesForIndexVariant
+    # indexVariantsAndStudiesForTagVariant(
+    #   variantId: String!
+    # ): IndexVariantsAndStudiesForTagVariant
+    # tagVariantsAndStudiesForIndexVariant(
+    #   variantId: String!
+    # ): TagVariantsAndStudiesForIndexVariant
   }
   type SearchResult {
     genes: [SearchResultGene!]!
@@ -148,45 +148,45 @@ export const typeDefs = gql`
   #   id: String
   #   symbol: String
   # }
-  type IndexVariantsAndStudiesForTagVariant {
-    rows: [IndexVariantAndStudyForTagVariant!]!
-  }
-  type IndexVariantAndStudyForTagVariant {
-    indexVariantId: String!
-    indexVariantRsId: String!
-    studyId: String!
-    traitReported: String!
-    pval: Float!
-    # publication info
-    pmid: String
-    pubDate: String
-    pubAuthor: String
-    nTotal: Int # n_initial + n_replication
-    # ld info is optional; but expect all or none of the following
-    overallR2: Float # 0.7 - 1
-    # finemapping is optional; but expect all or none of the following
-    isInCredibleSet: Boolean
-  }
-  type TagVariantsAndStudiesForIndexVariant {
-    rows: [TagVariantAndStudyForIndexVariant!]!
-  }
-  type TagVariantAndStudyForIndexVariant {
-    tagVariantId: String!
-    tagVariantRsId: String!
-    studyId: String!
-    traitReported: String!
-    pval: Float!
-    # publication info
-    pmid: String
-    pubDate: String
-    pubAuthor: String
-    nTotal: Int # n_initial + n_replication
-    # ld info is optional; but expect all or none of the following
-    overallR2: Float # 0.7 - 1
-    # finemapping is optional; but expect all or none of the following
-    isInCredibleSet: Boolean
-    posteriorProbability: Float # 0 - 1
-  }
+  # type IndexVariantsAndStudiesForTagVariant {
+  #   rows: [IndexVariantAndStudyForTagVariant!]!
+  # }
+  # type IndexVariantAndStudyForTagVariant {
+  #   indexVariantId: String!
+  #   indexVariantRsId: String!
+  #   studyId: String!
+  #   traitReported: String!
+  #   pval: Float!
+  #   # publication info
+  #   pmid: String
+  #   pubDate: String
+  #   pubAuthor: String
+  #   nTotal: Int # n_initial + n_replication
+  #   # ld info is optional; but expect all or none of the following
+  #   overallR2: Float # 0.7 - 1
+  #   # finemapping is optional; but expect all or none of the following
+  #   isInCredibleSet: Boolean
+  # }
+  # type TagVariantsAndStudiesForIndexVariant {
+  #   rows: [TagVariantAndStudyForIndexVariant!]!
+  # }
+  # type TagVariantAndStudyForIndexVariant {
+  #   tagVariantId: String!
+  #   tagVariantRsId: String!
+  #   studyId: String!
+  #   traitReported: String!
+  #   pval: Float!
+  #   # publication info
+  #   pmid: String
+  #   pubDate: String
+  #   pubAuthor: String
+  #   nTotal: Int # n_initial + n_replication
+  #   # ld info is optional; but expect all or none of the following
+  #   overallR2: Float # 0.7 - 1
+  #   # finemapping is optional; but expect all or none of the following
+  #   isInCredibleSet: Boolean
+  #   posteriorProbability: Float # 0 - 1
+  # }
   # type Regional {
   #     associations: [RegionalAssociation!]!
   # }

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -79,7 +79,7 @@ const StudyPage = ({ match }) => {
 
       <Query
         query={manhattanQuery}
-        variables={{ studyId: match.params.studyId }}
+        variables={{ studyId }}
         fetchPolicy="network-only"
       >
         {({ loading, error, data }) => {


### PR DESCRIPTION
This PR updates the variant page's associated tag and index variant tables to use live data. This requires a couple of simple transformation functions, since the data shape is slightly different from that mocked.