### PR TITLE
Scroll to top of the page using the ScrollToTop component

### DIFF
--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -1,0 +1,21 @@
+import { Component } from 'react';
+import { withRouter } from 'react-router';
+
+class ScrollToTop extends Component {
+  componentDidMount() {
+    window.scrollTo(0, 0);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { onRouteChange, location } = this.props;
+    if (onRouteChange && location !== prevProps.location) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export default withRouter(ScrollToTop);

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -8,6 +8,7 @@ import { Manhattan } from 'ot-charts';
 
 import BasePage from './BasePage';
 import ManhattanTable, { tableColumns } from '../components/ManhattanTable';
+import ScrollToTop from '../components/ScrollToTop';
 import withTooltip from '../components/withTooltip';
 
 const ManhattanWithTooltip = withTooltip(Manhattan, tableColumns);
@@ -79,6 +80,7 @@ const StudyPage = ({ match }) => {
   const { studyId } = match.params;
   return (
     <BasePage>
+      <ScrollToTop onRouteChange />
       <Helmet>
         <title>{studyId}</title>
       </Helmet>

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -11,6 +11,7 @@ import AssociatedGenesTable from '../components/AssociatedGenesTable';
 import PheWASTable, { tableColumns } from '../components/PheWASTable';
 import AssociatedTagVariantsTable from '../components/AssociatedTagVariantsTable';
 import AssociatedIndexVariantsTable from '../components/AssociatedIndexVariantsTable';
+import ScrollToTop from '../components/ScrollToTop';
 import withTooltip from '../components/withTooltip';
 
 const PheWASWithTooltip = withTooltip(PheWAS, tableColumns);
@@ -170,6 +171,7 @@ const VariantPage = ({ match }) => {
 
   return (
     <BasePage>
+      <ScrollToTop onRouteChange />
       <Helmet>
         <title>{variantId}</title>
       </Helmet>


### PR DESCRIPTION
This PR adds the `ScrollToTop` component which can be used on components where we want to scroll to go all the way to the top. It accepts an `onRouteChange` prop to indicate that we also want to scroll to the top when the route changes, in addition to the initial mount. The component is used in the `VariantPage` and `StudyPage`.