### PR TITLE
Use ModelSchematic component from ot-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "apollo-link-http": "^1.5.4",
     "apollo-link-schema": "^1.1.0",
     "casual-browserify": "^1.5.19-2",
+    "classnames": "^2.2.6",
     "d3": "^5.5.0",
     "fg-loadcss": "^2.0.1",
     "file-saver": "^1.3.8",

--- a/src/pages/LocusPage.js
+++ b/src/pages/LocusPage.js
@@ -7,8 +7,7 @@ import queryString from 'query-string';
 import { Gecko } from 'ot-charts';
 import {
   PageTitle,
-  Heading,
-  SubHeading,
+  SectionHeading,
   BrowserControls,
   commaSeparate,
 } from 'ot-ui';
@@ -193,11 +192,28 @@ class LocusPage extends React.Component {
           <title>{locationString}</title>
         </Helmet>
         <PageTitle>Locus {locationString}</PageTitle>
-        <hr />
-        <Heading>Associations</Heading>
-        <SubHeading>
-          What genetic evidence is there within this locus?
-        </SubHeading>
+        <SectionHeading
+          heading="Associations"
+          subheading="What genetic evidence is there within this locus?"
+          entities={[
+            {
+              type: 'study',
+              fixed: false,
+            },
+            {
+              type: 'indexVariant',
+              fixed: false,
+            },
+            {
+              type: 'tagVariant',
+              fixed: false,
+            },
+            {
+              type: 'gene',
+              fixed: false,
+            },
+          ]}
+        />
         <BrowserControls
           handleZoomIn={this.handleZoomIn}
           handleZoomOut={this.handleZoomOut}

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -3,13 +3,7 @@ import { Helmet } from 'react-helmet';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
-import {
-  PageTitle,
-  Heading,
-  SubHeading,
-  DownloadSVGPlot,
-  ModelSchematic,
-} from 'ot-ui';
+import { PageTitle, SubHeading, DownloadSVGPlot, SectionHeading } from 'ot-ui';
 import { Manhattan } from 'ot-charts';
 
 import BasePage from './BasePage';
@@ -120,17 +114,16 @@ const StudyPage = ({ match }) => {
                       {data.studyInfo.pmid}
                     </a>
                   </SubHeading>
-                  <hr />
                 </Fragment>
               ) : null}
               {hasAssociations(data) ? (
                 <Fragment>
-                  <Heading>Independently-associated loci</Heading>
-                  <SubHeading>
-                    {`Found ${significantLoci(data)} loci with genome-wide
+                  <SectionHeading
+                    heading="Independently-associated loci"
+                    subheading={`Found ${significantLoci(
+                      data
+                    )} loci with genome-wide
                   significance (p-value < 5e-8)`}
-                  </SubHeading>
-                  <ModelSchematic
                     entities={[
                       {
                         type: 'study',
@@ -142,6 +135,7 @@ const StudyPage = ({ match }) => {
                       },
                     ]}
                   />
+
                   <DownloadSVGPlot
                     svgContainer={manhattanPlot}
                     filenameStem={`${studyId}-independently-associated-loci`}

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -3,7 +3,13 @@ import { Helmet } from 'react-helmet';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
-import { PageTitle, Heading, SubHeading, DownloadSVGPlot } from 'ot-ui';
+import {
+  PageTitle,
+  Heading,
+  SubHeading,
+  DownloadSVGPlot,
+  ModelSchematic,
+} from 'ot-ui';
 import { Manhattan } from 'ot-charts';
 
 import BasePage from './BasePage';
@@ -124,6 +130,18 @@ const StudyPage = ({ match }) => {
                     {`Found ${significantLoci(data)} loci with genome-wide
                   significance (p-value < 5e-8)`}
                   </SubHeading>
+                  <ModelSchematic
+                    entities={[
+                      {
+                        type: 'study',
+                        fixed: true,
+                      },
+                      {
+                        type: 'indexVariant',
+                        fixed: false,
+                      },
+                    ]}
+                  />
                   <DownloadSVGPlot
                     svgContainer={manhattanPlot}
                     filenameStem={`${studyId}-independently-associated-loci`}

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -3,13 +3,7 @@ import { Helmet } from 'react-helmet';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
-import {
-  PageTitle,
-  Heading,
-  SubHeading,
-  DownloadSVGPlot,
-  ModelSchematic,
-} from 'ot-ui';
+import { PageTitle, DownloadSVGPlot, SectionHeading } from 'ot-ui';
 import { PheWAS } from 'ot-charts';
 
 import BasePage from './BasePage';
@@ -182,12 +176,9 @@ const VariantPage = ({ match }) => {
         <title>{variantId}</title>
       </Helmet>
       <PageTitle>{`Variant ${variantId}`}</PageTitle>
-      <hr />
-      <Heading>Assigned genes</Heading>
-      <SubHeading>
-        Which genes are functionally implicated by this variant?
-      </SubHeading>
-      <ModelSchematic
+      <SectionHeading
+        heading="Assigned genes"
+        subheading="Which genes are functionally implicated by this variant?"
         entities={[
           {
             type: 'variant',
@@ -214,12 +205,9 @@ const VariantPage = ({ match }) => {
         {({ loading, error, data }) => {
           return hasAssociations(data) ? (
             <Fragment>
-              <hr />
-              <Heading>PheWAS</Heading>
-              <SubHeading>
-                Which traits are associated with this variant in UK Biobank?
-              </SubHeading>
-              <ModelSchematic
+              <SectionHeading
+                heading="PheWAS"
+                subheading="Which traits are associated with this variant in UK Biobank?"
                 entities={[
                   {
                     type: 'study',
@@ -250,12 +238,9 @@ const VariantPage = ({ match }) => {
         {({ loading, error, data }) => {
           return hasAssociatedIndexVariants(data) ? (
             <Fragment>
-              <hr />
-              <Heading>GWAS lead variants</Heading>
-              <SubHeading>
-                Which GWAS lead variants are linked with this variant?
-              </SubHeading>
-              <ModelSchematic
+              <SectionHeading
+                heading="GWAS lead variants"
+                subheading="Which GWAS lead variants are linked with this variant?"
                 entities={[
                   {
                     type: 'study',
@@ -288,13 +273,9 @@ const VariantPage = ({ match }) => {
         {({ loading, error, data }) => {
           return hasAssociatedTagVariants(data) ? (
             <Fragment>
-              <hr />
-              <Heading>Tag variants</Heading>
-              <SubHeading>
-                Which variants tag (through LD or finemapping) this lead
-                variant?
-              </SubHeading>
-              <ModelSchematic
+              <SectionHeading
+                heading="Tag variants"
+                subheading="Which variants tag (through LD or finemapping) this lead variant?"
                 entities={[
                   {
                     type: 'study',

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -3,7 +3,13 @@ import { Helmet } from 'react-helmet';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
-import { PageTitle, Heading, SubHeading, DownloadSVGPlot } from 'ot-ui';
+import {
+  PageTitle,
+  Heading,
+  SubHeading,
+  DownloadSVGPlot,
+  ModelSchematic,
+} from 'ot-ui';
 import { PheWAS } from 'ot-charts';
 
 import BasePage from './BasePage';
@@ -181,6 +187,18 @@ const VariantPage = ({ match }) => {
       <SubHeading>
         Which genes are functionally implicated by this variant?
       </SubHeading>
+      <ModelSchematic
+        entities={[
+          {
+            type: 'variant',
+            fixed: true,
+          },
+          {
+            type: 'gene',
+            fixed: false,
+          },
+        ]}
+      />
       <Query query={associatedGenesQuery} variables={{ variantId }}>
         {({ loading, error, data }) => {
           return hasAssociatedGenes(data) ? (
@@ -201,6 +219,18 @@ const VariantPage = ({ match }) => {
               <SubHeading>
                 Which traits are associated with this variant in UK Biobank?
               </SubHeading>
+              <ModelSchematic
+                entities={[
+                  {
+                    type: 'study',
+                    fixed: false,
+                  },
+                  {
+                    type: 'variant',
+                    fixed: true,
+                  },
+                ]}
+              />
               <DownloadSVGPlot
                 svgContainer={pheWASPlot}
                 filenameStem={`${variantId}-traits`}
@@ -225,6 +255,22 @@ const VariantPage = ({ match }) => {
               <SubHeading>
                 Which GWAS lead variants are linked with this variant?
               </SubHeading>
+              <ModelSchematic
+                entities={[
+                  {
+                    type: 'study',
+                    fixed: false,
+                  },
+                  {
+                    type: 'indexVariant',
+                    fixed: false,
+                  },
+                  {
+                    type: 'tagVariant',
+                    fixed: true,
+                  },
+                ]}
+              />
               <AssociatedIndexVariantsTable
                 data={
                   transformAssociatedIndexVariants(
@@ -248,6 +294,22 @@ const VariantPage = ({ match }) => {
                 Which variants tag (through LD or finemapping) this lead
                 variant?
               </SubHeading>
+              <ModelSchematic
+                entities={[
+                  {
+                    type: 'study',
+                    fixed: false,
+                  },
+                  {
+                    type: 'indexVariant',
+                    fixed: true,
+                  },
+                  {
+                    type: 'tagVariant',
+                    fixed: false,
+                  },
+                ]}
+              />
               <AssociatedTagVariantsTable
                 data={
                   transformAssociatedTagVariants(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1778,7 +1778,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.3, classnames@^2.2.5:
+classnames@^2.2.3, classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
 


### PR DESCRIPTION
This PR uses the ModelSchematic component added in https://github.com/opentargets/ot-ui/pull/24 to help explain the various sections on the variant, study and locus pages.