### PR TITLE
Append marker to rows when index or tag matches that of the page

### DIFF
--- a/src/components/AssociatedIndexVariantsTable.js
+++ b/src/components/AssociatedIndexVariantsTable.js
@@ -6,13 +6,14 @@ const tableColumns = variantId => [
   {
     id: 'indexVariantId',
     label: 'Variant',
-    renderCell: rowData => (
-      <Link to={`/variant/${rowData.indexVariantId}`}>
-        {variantId === rowData.indexVariantId
-          ? `${rowData.indexVariantId} (self)`
-          : rowData.indexVariantId}
-      </Link>
-    ),
+    renderCell: rowData =>
+      variantId !== rowData.indexVariantId ? (
+        <Link to={`/variant/${rowData.indexVariantId}`}>
+          {rowData.indexVariantId}
+        </Link>
+      ) : (
+        `${rowData.indexVariantId} (self)`
+      ),
   },
   { id: 'indexVariantRsId', label: 'rsID' },
   {

--- a/src/components/AssociatedIndexVariantsTable.js
+++ b/src/components/AssociatedIndexVariantsTable.js
@@ -2,13 +2,15 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { OtTable, commaSeparate } from 'ot-ui';
 
-const tableColumns = [
+const tableColumns = variantId => [
   {
     id: 'indexVariantId',
     label: 'Variant',
     renderCell: rowData => (
       <Link to={`/variant/${rowData.indexVariantId}`}>
-        {rowData.indexVariantId}
+        {variantId === rowData.indexVariantId
+          ? `${rowData.indexVariantId} (self)`
+          : rowData.indexVariantId}
       </Link>
     ),
   },
@@ -69,9 +71,10 @@ const AssociatedIndexVariantsTable = ({
   error,
   filenameStem,
   data,
+  variantId,
 }) => (
   <OtTable
-    columns={tableColumns}
+    columns={tableColumns(variantId)}
     data={data}
     sortBy="pval"
     order="asc"

--- a/src/components/AssociatedTagVariantsTable.js
+++ b/src/components/AssociatedTagVariantsTable.js
@@ -6,13 +6,14 @@ const tableColumns = variantId => [
   {
     id: 'tagVariantId',
     label: 'Variant',
-    renderCell: rowData => (
-      <Link to={`/variant/${rowData.tagVariantId}`}>
-        {variantId === rowData.tagVariantId
-          ? `${rowData.tagVariantId} (self)`
-          : rowData.tagVariantId}
-      </Link>
-    ),
+    renderCell: rowData =>
+      variantId !== rowData.tagVariantId ? (
+        <Link to={`/variant/${rowData.tagVariantId}`}>
+          {rowData.tagVariantId}
+        </Link>
+      ) : (
+        `${rowData.tagVariantId} (self)`
+      ),
   },
   { id: 'tagVariantRsId', label: 'rsID' },
   {

--- a/src/components/AssociatedTagVariantsTable.js
+++ b/src/components/AssociatedTagVariantsTable.js
@@ -2,13 +2,15 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { OtTable, commaSeparate } from 'ot-ui';
 
-const tableColumns = [
+const tableColumns = variantId => [
   {
     id: 'tagVariantId',
     label: 'Variant',
     renderCell: rowData => (
       <Link to={`/variant/${rowData.tagVariantId}`}>
-        {rowData.tagVariantId}
+        {variantId === rowData.tagVariantId
+          ? `${rowData.tagVariantId} (self)`
+          : rowData.tagVariantId}
       </Link>
     ),
   },
@@ -69,9 +71,15 @@ const tableColumns = [
   },
 ];
 
-const AssociatedTagVariantsTable = ({ loading, error, filenameStem, data }) => (
+const AssociatedTagVariantsTable = ({
+  loading,
+  error,
+  filenameStem,
+  data,
+  variantId,
+}) => (
   <OtTable
-    columns={tableColumns}
+    columns={tableColumns(variantId)}
     data={data}
     sortBy="pval"
     order="asc"

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -231,6 +231,7 @@ const VariantPage = ({ match }) => {
                     data.indexVariantsAndStudiesForTagVariant
                   ).associations
                 }
+                variantId={variantId}
                 filenameStem={`${variantId}-lead-variants`}
               />
             </Fragment>
@@ -254,6 +255,7 @@ const VariantPage = ({ match }) => {
                     data.tagVariantsAndStudiesForIndexVariant
                   ).associations
                 }
+                variantId={variantId}
                 filenameStem={`${variantId}-tag-variants`}
               />
             </Fragment>


### PR DESCRIPTION
Show **1_100335977_A_G (self)** instead of **1_100335977_A_G** when an associated tag variant or associated index variant matches the variant whose page we are on.