### PR TITLE
Improvements to Assigned Genes tabs and tables

### DIFF
--- a/src/components/AssociatedGenes.js
+++ b/src/components/AssociatedGenes.js
@@ -1,6 +1,5 @@
 import React, { Component, Fragment } from 'react';
 import * as d3 from 'd3';
-import { withStyles } from '@material-ui/core/styles';
 
 import { OtTable, Tabs, Tab, DataCircle, LabelHML } from 'ot-ui';
 
@@ -11,7 +10,7 @@ const radiusScale = d3
   .domain([0, 1])
   .range([0, 6]);
 
-const createQtlCellRenderer = (schema, classes) => {
+const createQtlCellRenderer = schema => {
   return rowData => {
     if (rowData[schema.sourceId] !== undefined) {
       const circleRadius = radiusScale(rowData[schema.sourceId]);
@@ -20,7 +19,7 @@ const createQtlCellRenderer = (schema, classes) => {
   };
 };
 
-const createIntervalCellRenderer = (schema, classes) => {
+const createIntervalCellRenderer = schema => {
   return rowData => {
     if (rowData[schema.sourceId] !== undefined) {
       const circleRadius = radiusScale(rowData[schema.sourceId]);
@@ -29,7 +28,7 @@ const createIntervalCellRenderer = (schema, classes) => {
   };
 };
 
-const createFPCellRenderer = (genesForVariant, classes) => {
+const createFPCellRenderer = genesForVariant => {
   return rowData => {
     const gene = genesForVariant.find(
       geneForVariant => geneForVariant.gene.symbol === rowData.geneSymbol
@@ -51,7 +50,7 @@ const createFPCellRenderer = (genesForVariant, classes) => {
   };
 };
 
-const getColumnsAll = (genesForVariantSchema, genesForVariant, classes) => {
+const getColumnsAll = (genesForVariantSchema, genesForVariant) => {
   const overallScoreScale = d3
     .scaleSqrt()
     .domain([
@@ -72,17 +71,17 @@ const getColumnsAll = (genesForVariantSchema, genesForVariant, classes) => {
     ...genesForVariantSchema.qtls.map(schema => ({
       id: schema.sourceId,
       label: schema.sourceId,
-      renderCell: createQtlCellRenderer(schema, classes),
+      renderCell: createQtlCellRenderer(schema),
     })),
     ...genesForVariantSchema.intervals.map(schema => ({
       id: schema.sourceId,
       label: schema.sourceId,
-      renderCell: createIntervalCellRenderer(schema, classes),
+      renderCell: createIntervalCellRenderer(schema),
     })),
     ...genesForVariantSchema.functionalPredictions.map(schema => ({
       id: schema.sourceId,
       label: schema.sourceId,
-      renderCell: createFPCellRenderer(genesForVariant, classes),
+      renderCell: createFPCellRenderer(genesForVariant),
     })),
   ];
 
@@ -234,23 +233,6 @@ const getTissueData = (genesForVariantSchema, genesForVariant, sourceId) => {
   return data;
 };
 
-const styles = theme => {
-  return {
-    overallScoreCircle: {
-      fill: theme.palette.grey[600],
-    },
-    qtlIntervalCircle: {
-      fill: theme.palette.grey[500],
-    },
-    positiveBeta: {
-      fill: theme.palette.secondary.main,
-    },
-    negativeBeta: {
-      fill: theme.palette.primary.main,
-    },
-  };
-};
-
 class AssociatedGenes extends Component {
   state = {
     value: OVERVIEW,
@@ -262,7 +244,7 @@ class AssociatedGenes extends Component {
 
   render() {
     const { value } = this.state;
-    const { genesForVariantSchema, genesForVariant, classes } = this.props;
+    const { genesForVariantSchema, genesForVariant } = this.props;
 
     // Hardcoding the order and assuming qtls, intervals, and
     // functionalPredictions are the only fields in the schema
@@ -272,11 +254,7 @@ class AssociatedGenes extends Component {
       ...genesForVariantSchema.functionalPredictions,
     ];
 
-    const columnsAll = getColumnsAll(
-      genesForVariantSchema,
-      genesForVariant,
-      classes
-    );
+    const columnsAll = getColumnsAll(genesForVariantSchema, genesForVariant);
     const dataAll = getDataAll(genesForVariant);
 
     return (
@@ -302,8 +280,7 @@ class AssociatedGenes extends Component {
                 columns={getTissueColumns(
                   genesForVariantSchema,
                   genesForVariant,
-                  schema.sourceId,
-                  classes
+                  schema.sourceId
                 )}
                 data={getTissueData(
                   genesForVariantSchema,
@@ -319,4 +296,4 @@ class AssociatedGenes extends Component {
   }
 }
 
-export default withStyles(styles)(AssociatedGenes);
+export default AssociatedGenes;

--- a/src/components/AssociatedGenes.js
+++ b/src/components/AssociatedGenes.js
@@ -1,38 +1,127 @@
 import React, { Component, Fragment } from 'react';
+import * as d3 from 'd3';
+import { withStyles } from '@material-ui/core/styles';
+import classNames from 'classnames';
 
 import { OtTable, Tabs, Tab } from 'ot-ui';
 
 const OVERVIEW = 'overview';
 
-const getColumnsAll = schemas => {
+const DataCircle = ({ radius, className }) => {
+  return (
+    <svg width="12" height="12" xmlns="http://www.w3.org/2000/svg">
+      <circle cx={radius} cy={radius} r={radius} className={className} />
+    </svg>
+  );
+};
+
+const areaScale = d3
+  .scaleLinear()
+  .domain([0, 1])
+  .range([0, 36]);
+
+const getColumnsAll = (genesForVariantSchema, genesForVariant, classes) => {
+  const overallScoreScale = d3
+    .scaleLinear()
+    .domain([
+      0,
+      d3.max(genesForVariant, geneForVariant => geneForVariant.overallScore),
+    ])
+    .range([0, 36]);
   const columns = [
-    { id: 'gene', label: 'Gene' },
+    { id: 'geneSymbol', label: 'Gene' },
     {
       id: 'overallScore',
       label: 'Overall G2V',
       renderCell: rowData => {
-        return rowData.overallScore.toPrecision(3);
+        const circleArea = overallScoreScale(rowData.overallScore);
+        const circleRadius = Math.sqrt(circleArea);
+        return (
+          <DataCircle
+            radius={circleRadius}
+            className={classes.overallScoreCircle}
+          />
+        );
       },
     },
   ];
-  schemas.forEach(schema => {
+
+  genesForVariantSchema.qtls.forEach(schema => {
     columns.push({
       id: schema.sourceId,
       label: schema.sourceId,
       renderCell: rowData => {
-        return rowData[schema.sourceId]
-          ? rowData[schema.sourceId].toPrecision(3)
-          : 'No information';
+        if (rowData[schema.sourceId] !== undefined) {
+          const circleArea = areaScale(rowData[schema.sourceId]);
+          const circleRadius = Math.sqrt(circleArea);
+          return (
+            <DataCircle
+              radius={circleRadius}
+              className={classes.qtlIntervalCircle}
+            />
+          );
+        }
       },
     });
   });
+
+  genesForVariantSchema.intervals.forEach(schema => {
+    columns.push({
+      id: schema.sourceId,
+      label: schema.sourceId,
+      renderCell: rowData => {
+        if (rowData[schema.sourceId] !== undefined) {
+          const circleArea = areaScale(rowData[schema.sourceId]);
+          const circleRadius = Math.sqrt(circleArea);
+          return (
+            <DataCircle
+              radius={circleRadius}
+              className={classes.qtlIntervalCircle}
+            />
+          );
+        }
+      },
+    });
+  });
+
+  genesForVariantSchema.functionalPredictions.forEach(schema => {
+    columns.push({
+      id: schema.sourceId,
+      label: schema.sourceId,
+      renderCell: rowData => {
+        const gene = genesForVariant.find(
+          geneForVariant => geneForVariant.gene.symbol === rowData.geneSymbol
+        );
+
+        if (gene.functionalPredictions.length === 1) {
+          const {
+            maxEffectLabel,
+            maxEffectScore,
+          } = gene.functionalPredictions[0].tissues[0];
+          const labelClass = classNames({
+            [classes.maxEffectLow]:
+              0 <= maxEffectScore && maxEffectScore <= 1 / 3,
+            [classes.maxEffectMedium]:
+              1 / 3 < maxEffectScore && maxEffectScore <= 2 / 3,
+            [classes.maxEffectHigh]:
+              2 / 3 < maxEffectScore && maxEffectScore <= 1,
+          });
+          return <span className={labelClass}>{maxEffectLabel}</span>;
+        }
+      },
+    });
+  });
+
   return columns;
 };
 
 const getDataAll = genesForVariant => {
   const data = [];
   genesForVariant.forEach(item => {
-    const row = { gene: item.gene.symbol, overallScore: item.overallScore };
+    const row = {
+      geneSymbol: item.gene.symbol,
+      overallScore: item.overallScore,
+    };
     item.qtls.forEach(qtl => {
       row[qtl.sourceId] = qtl.aggregatedScore;
     });
@@ -47,22 +136,87 @@ const getDataAll = genesForVariant => {
   return data;
 };
 
-const getTissueColumns = (schemas, sourceId) => {
-  const columns = [{ id: 'gene', label: 'Gene' }];
-  schemas
-    .find(schema => schema.sourceId === sourceId)
-    .tissues.forEach(tissue => {
-      columns.push({
-        id: tissue.id,
-        label: tissue.name,
-        renderCell: rowData => {
-          return rowData[tissue.id]
-            ? rowData[tissue.id].toPrecision(3)
-            : 'No information';
-        },
-      });
+const getTissueColumns = (
+  genesForVariantSchema,
+  genesForVariant,
+  sourceId,
+  classes
+) => {
+  const columns = [{ id: 'geneSymbol', label: 'Gene' }];
+  let type;
+  let schema;
+
+  genesForVariantSchema.qtls.forEach(s => {
+    if (s.sourceId === sourceId) {
+      type = 'qtls';
+      schema = s;
+    }
+  });
+
+  !schema &&
+    genesForVariantSchema.intervals.forEach(s => {
+      if (s.sourceId === sourceId) {
+        type = 'intervals';
+        schema = s;
+      }
     });
+
+  !schema &&
+    genesForVariantSchema.functionalPredictions.forEach(s => {
+      if (s.sourceId === sourceId) {
+        type = 'functionalPredictions';
+        schema = s;
+      }
+    });
+
+  schema.tissues.forEach(tissue => {
+    columns.push({
+      id: tissue.id,
+      label: tissue.name,
+      renderCell: rowData => {
+        if (rowData[tissue.id]) {
+          switch (type) {
+            case 'qtls':
+              const qtlArea = areaScale(rowData[tissue.id]);
+              const qtlRadius = Math.sqrt(qtlArea);
+              const beta = findBeta(
+                genesForVariant,
+                rowData.geneSymbol,
+                schema.sourceId,
+                tissue.id
+              );
+              const qtlClass =
+                beta > 0 ? classes.positiveBeta : classes.negativeBeta;
+              console.log('beta', tissue.id, beta);
+              return <DataCircle radius={qtlRadius} className={qtlClass} />;
+            case 'intervals':
+              const intervalArea = areaScale(rowData[tissue.id]);
+              const intervalRadius = Math.sqrt(intervalArea);
+              return (
+                <DataCircle
+                  radius={intervalRadius}
+                  className={classes.qtlIntervalCircle}
+                />
+              );
+            case 'functionalPredictions':
+            default:
+              return rowData[tissue.id];
+          }
+        }
+      },
+    });
+  });
+
   return columns;
+};
+
+const findBeta = (genesForVariant, geneSymbol, sourceId, tissueId) => {
+  const gene = genesForVariant.find(
+    geneForVariant => geneForVariant.gene.symbol === geneSymbol
+  );
+  const qtl = gene.qtls.find(qtl => qtl.sourceId === sourceId);
+  const tissue = qtl.tissues.find(tissue => tissue.tissue.id === tissueId);
+  return tissue.beta;
 };
 
 const getTissueData = (genesForVariantSchema, genesForVariant, sourceId) => {
@@ -90,7 +244,7 @@ const getTissueData = (genesForVariantSchema, genesForVariant, sourceId) => {
     });
 
   genesForVariant.forEach(geneForVariant => {
-    const row = { gene: geneForVariant.gene.symbol };
+    const row = { geneSymbol: geneForVariant.gene.symbol };
     const element = geneForVariant[searchField].find(
       item => item.sourceId === sourceId
     );
@@ -98,13 +252,39 @@ const getTissueData = (genesForVariantSchema, genesForVariant, sourceId) => {
     if (element) {
       element.tissues.forEach(elementTissue => {
         row[elementTissue.tissue.id] =
-          elementTissue.score || elementTissue.beta;
+          elementTissue.maxEffectLabel || elementTissue.quantile;
       });
     }
 
     data.push(row);
   });
   return data;
+};
+
+const styles = theme => {
+  return {
+    overallScoreCircle: {
+      fill: theme.palette.grey[600],
+    },
+    qtlIntervalCircle: {
+      fill: theme.palette.grey[500],
+    },
+    maxEffectHigh: {
+      color: theme.palette.high,
+    },
+    maxEffectMedium: {
+      color: theme.palette.medium,
+    },
+    maxEffectLow: {
+      color: theme.palette.low,
+    },
+    positiveBeta: {
+      fill: theme.palette.secondary.main,
+    },
+    negativeBeta: {
+      fill: theme.palette.primary.main,
+    },
+  };
 };
 
 class AssociatedGenes extends Component {
@@ -118,7 +298,7 @@ class AssociatedGenes extends Component {
 
   render() {
     const { value } = this.state;
-    const { genesForVariantSchema, genesForVariant } = this.props.data;
+    const { genesForVariantSchema, genesForVariant, classes } = this.props;
 
     // Hardcoding the order and assuming qtls, intervals, and
     // functionalPredictions are the only fields in the schema
@@ -128,16 +308,18 @@ class AssociatedGenes extends Component {
       ...genesForVariantSchema.functionalPredictions,
     ];
 
-    const filteredSchemas = schemas.filter(schema => schema.tissues.length > 1);
-
-    const columnsAll = getColumnsAll(schemas);
+    const columnsAll = getColumnsAll(
+      genesForVariantSchema,
+      genesForVariant,
+      classes
+    );
     const dataAll = getDataAll(genesForVariant);
 
     return (
       <Fragment>
         <Tabs value={value} onChange={this.handleChange}>
           <Tab label="All" value={OVERVIEW} />
-          {filteredSchemas.map(schema => {
+          {schemas.map(schema => {
             return (
               <Tab
                 key={schema.sourceId}
@@ -148,12 +330,17 @@ class AssociatedGenes extends Component {
           })}
         </Tabs>
         {value === OVERVIEW && <OtTable columns={columnsAll} data={dataAll} />}
-        {filteredSchemas.map(schema => {
+        {schemas.map(schema => {
           return (
             value === schema.sourceId && (
               <OtTable
                 key={schema.sourceId}
-                columns={getTissueColumns(schemas, schema.sourceId)}
+                columns={getTissueColumns(
+                  genesForVariantSchema,
+                  genesForVariant,
+                  schema.sourceId,
+                  classes
+                )}
                 data={getTissueData(
                   genesForVariantSchema,
                   genesForVariant,
@@ -168,4 +355,4 @@ class AssociatedGenes extends Component {
   }
 }
 
-export default AssociatedGenes;
+export default withStyles(styles)(AssociatedGenes);

--- a/src/components/AssociatedGenes.js
+++ b/src/components/AssociatedGenes.js
@@ -1,9 +1,8 @@
 import React, { Component, Fragment } from 'react';
 import * as d3 from 'd3';
 import { withStyles } from '@material-ui/core/styles';
-import classNames from 'classnames';
 
-import { OtTable, Tabs, Tab } from 'ot-ui';
+import { OtTable, Tabs, Tab, LabelHML } from 'ot-ui';
 
 const OVERVIEW = 'overview';
 
@@ -59,13 +58,13 @@ const createFPCellRenderer = (genesForVariant, classes) => {
         maxEffectLabel,
         maxEffectScore,
       } = gene.functionalPredictions[0].tissues[0];
-      const labelClass = classNames({
-        [classes.maxEffectLow]: 0 <= maxEffectScore && maxEffectScore <= 1 / 3,
-        [classes.maxEffectMedium]:
-          1 / 3 < maxEffectScore && maxEffectScore <= 2 / 3,
-        [classes.maxEffectHigh]: 2 / 3 < maxEffectScore && maxEffectScore <= 1,
-      });
-      return <span className={labelClass}>{maxEffectLabel}</span>;
+      const level =
+        0 <= maxEffectScore && maxEffectScore <= 1 / 3
+          ? 'L'
+          : 1 / 3 < maxEffectScore && maxEffectScore <= 2 / 3
+            ? 'M'
+            : 'H';
+      return <LabelHML level={level}>{maxEffectLabel}</LabelHML>;
     }
   };
 };
@@ -263,15 +262,6 @@ const styles = theme => {
     },
     qtlIntervalCircle: {
       fill: theme.palette.grey[500],
-    },
-    maxEffectHigh: {
-      color: theme.palette.high,
-    },
-    maxEffectMedium: {
-      color: theme.palette.medium,
-    },
-    maxEffectLow: {
-      color: theme.palette.low,
     },
     positiveBeta: {
       fill: theme.palette.secondary.main,

--- a/src/components/AssociatedGenes.js
+++ b/src/components/AssociatedGenes.js
@@ -219,7 +219,9 @@ const getTissueData = (genesForVariantSchema, genesForVariant, sourceId) => {
     if (element) {
       element.tissues.forEach(elementTissue => {
         row[elementTissue.tissue.id] =
-          elementTissue.maxEffectLabel || elementTissue.quantile;
+          elementTissue.__typename === 'FPredTissue'
+            ? elementTissue.maxEffectLabel
+            : elementTissue.quantile;
       });
     }
 

--- a/src/components/AssociatedGenes.js
+++ b/src/components/AssociatedGenes.js
@@ -15,27 +15,26 @@ const DataCircle = ({ radius, className }) => {
   );
 };
 
-const areaScale = d3
-  .scaleLinear()
+const radiusScale = d3
+  .scaleSqrt()
   .domain([0, 1])
-  .range([0, 36]);
+  .range([0, 6]);
 
 const getColumnsAll = (genesForVariantSchema, genesForVariant, classes) => {
   const overallScoreScale = d3
-    .scaleLinear()
+    .scaleSqrt()
     .domain([
       0,
       d3.max(genesForVariant, geneForVariant => geneForVariant.overallScore),
     ])
-    .range([0, 36]);
+    .range([0, 6]);
   const columns = [
     { id: 'geneSymbol', label: 'Gene' },
     {
       id: 'overallScore',
       label: 'Overall G2V',
       renderCell: rowData => {
-        const circleArea = overallScoreScale(rowData.overallScore);
-        const circleRadius = Math.sqrt(circleArea);
+        const circleRadius = overallScoreScale(rowData.overallScore);
         return (
           <DataCircle
             radius={circleRadius}
@@ -52,8 +51,7 @@ const getColumnsAll = (genesForVariantSchema, genesForVariant, classes) => {
       label: schema.sourceId,
       renderCell: rowData => {
         if (rowData[schema.sourceId] !== undefined) {
-          const circleArea = areaScale(rowData[schema.sourceId]);
-          const circleRadius = Math.sqrt(circleArea);
+          const circleRadius = radiusScale(rowData[schema.sourceId]);
           return (
             <DataCircle
               radius={circleRadius}
@@ -71,8 +69,7 @@ const getColumnsAll = (genesForVariantSchema, genesForVariant, classes) => {
       label: schema.sourceId,
       renderCell: rowData => {
         if (rowData[schema.sourceId] !== undefined) {
-          const circleArea = areaScale(rowData[schema.sourceId]);
-          const circleRadius = Math.sqrt(circleArea);
+          const circleRadius = radiusScale(rowData[schema.sourceId]);
           return (
             <DataCircle
               radius={circleRadius}
@@ -177,8 +174,7 @@ const getTissueColumns = (
         if (rowData[tissue.id]) {
           switch (type) {
             case 'qtls':
-              const qtlArea = areaScale(rowData[tissue.id]);
-              const qtlRadius = Math.sqrt(qtlArea);
+              const qtlRadius = radiusScale(rowData[tissue.id]);
               const beta = findBeta(
                 genesForVariant,
                 rowData.geneSymbol,
@@ -189,8 +185,7 @@ const getTissueColumns = (
                 beta > 0 ? classes.positiveBeta : classes.negativeBeta;
               return <DataCircle radius={qtlRadius} className={qtlClass} />;
             case 'intervals':
-              const intervalArea = areaScale(rowData[tissue.id]);
-              const intervalRadius = Math.sqrt(intervalArea);
+              const intervalRadius = radiusScale(rowData[tissue.id]);
               return (
                 <DataCircle
                   radius={intervalRadius}

--- a/src/components/AssociatedGenes.js
+++ b/src/components/AssociatedGenes.js
@@ -2,17 +2,9 @@ import React, { Component, Fragment } from 'react';
 import * as d3 from 'd3';
 import { withStyles } from '@material-ui/core/styles';
 
-import { OtTable, Tabs, Tab, LabelHML } from 'ot-ui';
+import { OtTable, Tabs, Tab, DataCircle, LabelHML } from 'ot-ui';
 
 const OVERVIEW = 'overview';
-
-const DataCircle = ({ radius, className }) => {
-  return (
-    <svg width="12" height="12" xmlns="http://www.w3.org/2000/svg">
-      <circle cx={radius} cy={radius} r={radius} className={className} />
-    </svg>
-  );
-};
 
 const radiusScale = d3
   .scaleSqrt()
@@ -23,12 +15,7 @@ const createQtlCellRenderer = (schema, classes) => {
   return rowData => {
     if (rowData[schema.sourceId] !== undefined) {
       const circleRadius = radiusScale(rowData[schema.sourceId]);
-      return (
-        <DataCircle
-          radius={circleRadius}
-          className={classes.qtlIntervalCircle}
-        />
-      );
+      return <DataCircle radius={circleRadius} colorScheme="default" />;
     }
   };
 };
@@ -37,12 +24,7 @@ const createIntervalCellRenderer = (schema, classes) => {
   return rowData => {
     if (rowData[schema.sourceId] !== undefined) {
       const circleRadius = radiusScale(rowData[schema.sourceId]);
-      return (
-        <DataCircle
-          radius={circleRadius}
-          className={classes.qtlIntervalCircle}
-        />
-      );
+      return <DataCircle radius={circleRadius} colorScheme="default" />;
     }
   };
 };
@@ -84,12 +66,7 @@ const getColumnsAll = (genesForVariantSchema, genesForVariant, classes) => {
       label: 'Overall G2V',
       renderCell: rowData => {
         const circleRadius = overallScoreScale(rowData.overallScore);
-        return (
-          <DataCircle
-            radius={circleRadius}
-            className={classes.overallScoreCircle}
-          />
-        );
+        return <DataCircle radius={circleRadius} colorScheme="bold" />;
       },
     },
     ...genesForVariantSchema.qtls.map(schema => ({
@@ -181,16 +158,12 @@ const getTissueColumns = (
                 schema.sourceId,
                 tissue.id
               );
-              const qtlClass =
-                beta > 0 ? classes.positiveBeta : classes.negativeBeta;
-              return <DataCircle radius={qtlRadius} className={qtlClass} />;
+              const qtlColor = beta > 0 ? 'red' : 'blue';
+              return <DataCircle radius={qtlRadius} colorScheme={qtlColor} />;
             case 'intervals':
               const intervalRadius = radiusScale(rowData[tissue.id]);
               return (
-                <DataCircle
-                  radius={intervalRadius}
-                  className={classes.qtlIntervalCircle}
-                />
+                <DataCircle radius={intervalRadius} colorScheme="default" />
               );
             case 'functionalPredictions':
             default:

--- a/src/components/AssociatedGenes.js
+++ b/src/components/AssociatedGenes.js
@@ -187,7 +187,6 @@ const getTissueColumns = (
               );
               const qtlClass =
                 beta > 0 ? classes.positiveBeta : classes.negativeBeta;
-              console.log('beta', tissue.id, beta);
               return <DataCircle radius={qtlRadius} className={qtlClass} />;
             case 'intervals':
               const intervalArea = areaScale(rowData[tissue.id]);

--- a/src/components/LocusTable.js
+++ b/src/components/LocusTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { OtTable, commaSeparate } from 'ot-ui';
+import { OtTable } from 'ot-ui';
 
 export const tableColumns = [
   {

--- a/src/graphql-mocking/mocks.js
+++ b/src/graphql-mocking/mocks.js
@@ -138,22 +138,6 @@ const mockVariantId = () => {
 const mockRsId = () => `rs${casual.integer(100, 100000)}`;
 
 const mocks = {
-  GenesForVariant: () => {
-    return {
-      genes: [
-        {
-          id: 'ENSG00000157764',
-          symbol: 'BRAF',
-          overallScore: 'High',
-        },
-        {
-          id: 'ENSG00000145335',
-          symbol: 'SNCA',
-          overallScore: 'Medium',
-        },
-      ],
-    };
-  },
   PheWAS: () => {
     // sample from the actual study names, then augment with other fields
     const associations = _.sampleSize(STUDIES, 100).map(d => ({

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { ApolloClient } from 'apollo-client';
 import { ApolloProvider } from 'react-apollo';
-import { InMemoryCache } from 'apollo-cache-inmemory';
+import { InMemoryCache, defaultDataIdFromObject } from 'apollo-cache-inmemory';
+import casual from 'casual-browserify';
 
 import App from './App';
 import { unregister } from './registerServiceWorker';
@@ -13,7 +14,18 @@ import getMockSchemaLink from './graphql-mocking/mockSchemaLink';
 getMockSchemaLink().then(mockSchemaLink => {
   const client = new ApolloClient({
     link: mockSchemaLink,
-    cache: new InMemoryCache(),
+    cache: new InMemoryCache({
+      dataIdFromObject: object => {
+        switch (object.__typename) {
+          case 'QTLElement':
+          case 'IntervalElement':
+          case 'FunctionalPredictionElement':
+            return casual.uuid;
+          default:
+            return defaultDataIdFromObject(object);
+        }
+      },
+    }),
   });
 
   ReactDOM.render(

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { ApolloClient } from 'apollo-client';
 import { ApolloProvider } from 'react-apollo';
-import { InMemoryCache, defaultDataIdFromObject } from 'apollo-cache-inmemory';
-import casual from 'casual-browserify';
+import { InMemoryCache } from 'apollo-cache-inmemory';
 
 import App from './App';
 import { unregister } from './registerServiceWorker';
@@ -14,18 +13,7 @@ import getMockSchemaLink from './graphql-mocking/mockSchemaLink';
 getMockSchemaLink().then(mockSchemaLink => {
   const client = new ApolloClient({
     link: mockSchemaLink,
-    cache: new InMemoryCache({
-      dataIdFromObject: object => {
-        switch (object.__typename) {
-          case 'QTLElement':
-          case 'IntervalElement':
-          case 'FunctionalPredictionElement':
-            return casual.uuid;
-          default:
-            return defaultDataIdFromObject(object);
-        }
-      },
-    }),
+    cache: new InMemoryCache(),
   });
 
   ReactDOM.render(

--- a/src/pages/LocusPage.js
+++ b/src/pages/LocusPage.js
@@ -34,7 +34,6 @@ function transformData(data, lookups) {
     tagVariantIndexVariantStudies,
     ...rest
   } = data.gecko;
-  const { tagVariants, indexVariants, studies } = rest;
   const { geneDict, tagVariantDict, indexVariantDict, studyDict } = lookups;
 
   // gene exons come as flat list, rendering expects list of pairs

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -238,7 +238,6 @@ const VariantPage = ({ match }) => {
         <title>{variantId}</title>
       </Helmet>
       <PageTitle>{`Variant ${variantId}`}</PageTitle>
-
       <Query query={variantPageQuery} variables={{ variantId }}>
         {({ loading, error, data }) => {
           const isGeneVariant = hasAssociatedGenes(data);

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -131,7 +131,6 @@ const variantPageQuery = gql`
       }
       overallScore
       qtls {
-        id
         sourceId
         aggregatedScore
         tissues {
@@ -145,7 +144,6 @@ const variantPageQuery = gql`
         }
       }
       intervals {
-        id
         sourceId
         aggregatedScore
         tissues {
@@ -158,7 +156,6 @@ const variantPageQuery = gql`
         }
       }
       functionalPredictions {
-        id
         sourceId
         aggregatedScore
         tissues {

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -294,7 +294,10 @@ const VariantPage = ({ match }) => {
                       },
                     ]}
                   />
-                  <AssociatedGenes data={data} />
+                  <AssociatedGenes
+                    genesForVariantSchema={data.genesForVariantSchema}
+                    genesForVariant={data.genesForVariant}
+                  />
                 </Fragment>
               ) : null}
               {isPheWASVariant ? (


### PR DESCRIPTION
This PR does the following:

- Displays tabs for all the sources, even if they only have 1 tissue.
- In the All tab, uses circles to display overallScore coloured with a darker grey
- In the All tab, uses circles to display aggregatedScore of qtls and interval sources coloured grey
- In the All tab, displays the maxEffectLabel of functional predictions coloured with high, medium, and low shades of blue
- In the tabs for the qtl and interval sources, uses circles using the value of quantile as the radius and the beta sign to display the circle as red or blue
- In the tab for functional prediction sources, the maxEffectLabel is used.