### PR TITLE
Remove id field in genesForVariant call as removed from API

### DIFF
--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -131,7 +131,6 @@ const variantPageQuery = gql`
       }
       overallScore
       qtls {
-        id
         sourceId
         aggregatedScore
         tissues {
@@ -145,7 +144,6 @@ const variantPageQuery = gql`
         }
       }
       intervals {
-        id
         sourceId
         aggregatedScore
         tissues {
@@ -158,7 +156,6 @@ const variantPageQuery = gql`
         }
       }
       functionalPredictions {
-        id
         sourceId
         aggregatedScore
         tissues {


### PR DESCRIPTION
This PR fixes the VariantPage, which was broken because the `genesForVariant(variantId)` call tried to get the `id` field of each source, but this is no longer in the schema.