### PR TITLE
Fix gecko query

### DIFF
--- a/src/pages/LocusPage.js
+++ b/src/pages/LocusPage.js
@@ -98,7 +98,7 @@ const FullWidthText = ({ children }) => (
 );
 
 const geckoQuery = gql`
-  query GeckoQuery($chromosome: String, $start: Int, $end: Int) {
+  query GeckoQuery($chromosome: String!, $start: Long!, $end: Long!) {
     gecko(chromosome: $chromosome, start: $start, end: $end) {
       genes {
         id


### PR DESCRIPTION
This PR fixes the gecko query in the `LocusPage`. Now the `gecko` query requires a `String!` for the chromosome, a `Long!` for the start, and a `Long!` for the end variables.