### PR TITLE
Refactor gecko logic and add display type toggle

### DIFF
--- a/src/logic/locusChained.js
+++ b/src/logic/locusChained.js
@@ -1,0 +1,82 @@
+const locusChained = ({ data, dataFiltered }) => {
+  const {
+    genes,
+    tagVariants,
+    indexVariants,
+    studies,
+    geneTagVariants,
+    tagVariantIndexVariantStudies,
+  } = data;
+
+  const {
+    genes: genesFiltered,
+    tagVariants: tagVariantsFiltered,
+    indexVariants: indexVariantsFiltered,
+    studies: studiesFiltered,
+    geneTagVariants: geneTagVariantsFiltered,
+    tagVariantIndexVariantStudies: tagVariantIndexVariantStudiesFiltered,
+  } = dataFiltered;
+
+  // show ALL genes
+  const geneDict = {};
+  const tagVariantDict = {};
+  const indexVariantDict = {};
+  const studyDict = {};
+  const geneTagVariantDict = {};
+  const tagVariantIndexVariantStudyDict = {};
+
+  genesFiltered.forEach(d => (geneDict[d.id] = true));
+  tagVariantsFiltered.forEach(d => (tagVariantDict[d.id] = true));
+  indexVariantsFiltered.forEach(d => (indexVariantDict[d.id] = true));
+  studiesFiltered.forEach(d => (studyDict[d.studyId] = true));
+  geneTagVariantsFiltered.forEach(
+    d => (geneTagVariantDict[`${d.geneId}-${d.tagVariantId}`] = true)
+  );
+  tagVariantIndexVariantStudiesFiltered.forEach(
+    d =>
+      (tagVariantIndexVariantStudyDict[
+        `${d.tagVariantId}-${d.indexVariantId}-${d.studyId}`
+      ] = true)
+  );
+
+  const genesWithChained = genes.map(d => ({
+    ...d,
+    chained: geneDict[d.id],
+  }));
+  const tagVariantsWithChained = tagVariants.map(d => ({
+    ...d,
+    chained: tagVariantDict[d.id],
+  }));
+  const indexVariantsWithChained = indexVariants.map(d => ({
+    ...d,
+    chained: indexVariantDict[d.id],
+  }));
+  const studiesWithChained = studies.map(d => ({
+    ...d,
+    chained: studyDict[d.studyId],
+  }));
+  const geneTagVariantsWithChained = geneTagVariants.map(d => ({
+    ...d,
+    chained: geneTagVariantDict[`${d.geneId}-${d.tagVariantId}`],
+  }));
+  const tagVariantIndexVariantStudiesWithChained = tagVariantIndexVariantStudies.map(
+    d => ({
+      ...d,
+      chained:
+        tagVariantIndexVariantStudyDict[
+          `${d.tagVariantId}-${d.indexVariantId}-${d.studyId}`
+        ],
+    })
+  );
+
+  return {
+    genes: genesWithChained,
+    tagVariants: tagVariantsWithChained,
+    indexVariants: indexVariantsWithChained,
+    studies: studiesWithChained,
+    geneTagVariants: geneTagVariantsWithChained,
+    tagVariantIndexVariantStudies: tagVariantIndexVariantStudiesWithChained,
+  };
+};
+
+export default locusChained;

--- a/src/logic/locusChained.js
+++ b/src/logic/locusChained.js
@@ -1,3 +1,11 @@
+const idField = d => d.id;
+const studyIdField = d => d.studyId;
+const gTvIdField = d => `${d.geneId}-${d.tagVariantId}`;
+const tvIvSIdField = d => `${d.tagVariantId}-${d.indexVariantId}-${d.studyId}`;
+const dictReducer = idFieldAccessor => (dict, d) => {
+  return (dict[idFieldAccessor(d)] = true);
+};
+
 const locusChained = ({ data, dataFiltered }) => {
   const {
     genes,
@@ -17,26 +25,21 @@ const locusChained = ({ data, dataFiltered }) => {
     tagVariantIndexVariantStudies: tagVariantIndexVariantStudiesFiltered,
   } = dataFiltered;
 
-  // show ALL genes
-  const geneDict = {};
-  const tagVariantDict = {};
-  const indexVariantDict = {};
-  const studyDict = {};
-  const geneTagVariantDict = {};
-  const tagVariantIndexVariantStudyDict = {};
-
-  genesFiltered.forEach(d => (geneDict[d.id] = true));
-  tagVariantsFiltered.forEach(d => (tagVariantDict[d.id] = true));
-  indexVariantsFiltered.forEach(d => (indexVariantDict[d.id] = true));
-  studiesFiltered.forEach(d => (studyDict[d.studyId] = true));
-  geneTagVariantsFiltered.forEach(
-    d => (geneTagVariantDict[`${d.geneId}-${d.tagVariantId}`] = true)
+  // build dicts
+  const geneDict = genesFiltered.reduce(dictReducer(idField), {});
+  const tagVariantDict = tagVariantsFiltered.reduce(dictReducer(idField), {});
+  const indexVariantDict = indexVariantsFiltered.reduce(
+    dictReducer(idField),
+    {}
   );
-  tagVariantIndexVariantStudiesFiltered.forEach(
-    d =>
-      (tagVariantIndexVariantStudyDict[
-        `${d.tagVariantId}-${d.indexVariantId}-${d.studyId}`
-      ] = true)
+  const studyDict = studiesFiltered.reduce(dictReducer(studyIdField), {});
+  const geneTagVariantDict = geneTagVariantsFiltered.reduce(
+    dictReducer(gTvIdField),
+    {}
+  );
+  const tagVariantIndexVariantStudyDict = tagVariantIndexVariantStudiesFiltered.reduce(
+    dictReducer(tvIvSIdField),
+    {}
   );
 
   const genesWithChained = genes.map(d => ({

--- a/src/logic/locusFilter.js
+++ b/src/logic/locusFilter.js
@@ -5,7 +5,6 @@ const locusFilter = ({
   selectedIndexVariants,
   selectedStudies,
 }) => {
-  // return data;
   const {
     genes,
     tagVariants,
@@ -15,13 +14,31 @@ const locusFilter = ({
     tagVariantIndexVariantStudies,
   } = data;
 
+  // add selected field
+  let genesUnfiltered = genes.map(d => ({
+    ...d,
+    selected: selectedGenes && selectedGenes.indexOf(d.id) >= 0,
+  }));
+  let tagVariantsUnfiltered = tagVariants.map(d => ({
+    ...d,
+    selected: selectedTagVariants && selectedTagVariants.indexOf(d.id) >= 0,
+  }));
+  let indexVariantsUnfiltered = indexVariants.map(d => ({
+    ...d,
+    selected: selectedIndexVariants && selectedIndexVariants.indexOf(d.id) >= 0,
+  }));
+  let studiesUnfiltered = studies.map(d => ({
+    ...d,
+    selected: selectedStudies && selectedStudies.indexOf(d.studyId) >= 0,
+  }));
+
   // copy original
-  let genesFiltered = genes.slice();
+  let genesFiltered = genesUnfiltered.slice();
   let geneTagVariantsFiltered = geneTagVariants.slice();
-  let tagVariantsFiltered = tagVariants.slice();
+  let tagVariantsFiltered = tagVariantsUnfiltered.slice();
   let tagVariantIndexVariantStudiesFiltered = tagVariantIndexVariantStudies.slice();
-  let indexVariantsFiltered = indexVariants.slice();
-  let studiesFiltered = studies.slice();
+  let indexVariantsFiltered = indexVariantsUnfiltered.slice();
+  let studiesFiltered = studiesUnfiltered.slice();
 
   // iterative filtering (uses AND between entities; OR within entities)
 
@@ -171,8 +188,16 @@ const locusFilter = ({
     genesFiltered = genesFiltered.filter(d => genesLeft[d.id]);
   }
 
+  // show ALL genes
+  const geneFilteredDict = {};
+  genesFiltered.forEach(d => (geneFilteredDict[d.id] = true));
+  const allGenesWithFilteredProp = genesUnfiltered.map(d => ({
+    ...d,
+    chained: geneFilteredDict[d.id],
+  }));
+
   return {
-    genes: genesFiltered,
+    genes: allGenesWithFilteredProp,
     tagVariants: tagVariantsFiltered,
     indexVariants: indexVariantsFiltered,
     studies: studiesFiltered,

--- a/src/logic/locusFilter.js
+++ b/src/logic/locusFilter.js
@@ -188,16 +188,8 @@ const locusFilter = ({
     genesFiltered = genesFiltered.filter(d => genesLeft[d.id]);
   }
 
-  // show ALL genes
-  const geneFilteredDict = {};
-  genesFiltered.forEach(d => (geneFilteredDict[d.id] = true));
-  const allGenesWithFilteredProp = genesUnfiltered.map(d => ({
-    ...d,
-    chained: geneFilteredDict[d.id],
-  }));
-
   return {
-    genes: allGenesWithFilteredProp,
+    genes: genesFiltered,
     tagVariants: tagVariantsFiltered,
     indexVariants: indexVariantsFiltered,
     studies: studiesFiltered,

--- a/src/logic/locusScheme.js
+++ b/src/logic/locusScheme.js
@@ -20,11 +20,6 @@ const locusScheme = ({
   selectedStudies,
 }) => {
   const lookups = locusLookups(data);
-  const noneSelected =
-    !selectedGenes &&
-    !selectedTagVariants &&
-    !selectedIndexVariants &&
-    !selectedStudies;
   const selected = locusSelected({
     data,
     selectedGenes,

--- a/src/logic/locusScheme.js
+++ b/src/logic/locusScheme.js
@@ -16,15 +16,6 @@ const geneTagVariantComparator = (a, b) => {
   const scoreA = (a.chained ? 1 : 0) + a.overallScore;
   const scoreB = (b.chained ? 1 : 0) + b.overallScore;
   return scoreA - scoreB;
-  // if (a.chained && b.chained) {
-  //   return a.overallScore - b.overallScore;
-  // } else if (a.chained) {
-  //   return 1;
-  // } else if (b.chained) {
-  //   return -1;
-  // } else {
-  //   return a.overallScore - b.overallScore;
-  // }
 };
 
 const tagVariantIndexVariantStudyComparator = (a, b) => {
@@ -32,15 +23,6 @@ const tagVariantIndexVariantStudyComparator = (a, b) => {
   const scoreA = (a.chained ? 2 : 0) + (a.finemapping ? 1 : 0) + a.r2;
   const scoreB = (b.chained ? 2 : 0) + (b.finemapping ? 1 : 0) + b.r2;
   return scoreA - scoreB;
-  // if (a.posteriorProbability && b.posteriorProbability) {
-  //   return a.r2 - b.r2;
-  // } else if (a.posteriorProbability) {
-  //   return 1;
-  // } else if (b.posteriorProbability) {
-  //   return -1;
-  // } else {
-  //   return a.r2 - b.r2;
-  // }
 };
 
 const locusScheme = ({

--- a/src/logic/locusScheme.js
+++ b/src/logic/locusScheme.js
@@ -1,0 +1,125 @@
+import locusFilter from './locusFilter';
+import locusSelected from './locusSelected';
+import locusTransform from './locusTransform';
+import locusChained from './locusChained';
+import locusLookups from './locusLookups';
+import locusTable from './locusTable';
+
+export const LOCUS_SCHEME = {
+  CHAINED: 1,
+  ALL: 2,
+  ALL_GENES: 3,
+};
+
+const locusScheme = ({
+  scheme,
+  data,
+  selectedGenes,
+  selectedTagVariants,
+  selectedIndexVariants,
+  selectedStudies,
+}) => {
+  const lookups = locusLookups(data);
+  const noneSelected =
+    !selectedGenes &&
+    !selectedTagVariants &&
+    !selectedIndexVariants &&
+    !selectedStudies;
+  const selected = locusSelected({
+    data,
+    selectedGenes,
+    selectedTagVariants,
+    selectedIndexVariants,
+    selectedStudies,
+  });
+  const transformed = locusTransform({ data: selected, lookups });
+  const filtered = locusFilter({
+    data: transformed,
+    selectedGenes,
+    selectedTagVariants,
+    selectedIndexVariants,
+    selectedStudies,
+  });
+  const chained = locusChained({
+    data: transformed,
+    dataFiltered: filtered,
+  });
+  const {
+    genes,
+    tagVariants,
+    indexVariants,
+    studies,
+    geneTagVariants,
+    tagVariantIndexVariantStudies,
+  } = chained;
+
+  const genesFiltered = genes.filter(d => d.chained);
+  const tagVariantsFiltered = tagVariants.filter(d => d.chained);
+  const indexVariantsFiltered = indexVariants.filter(d => d.chained);
+  const studiesFiltered = studies.filter(d => d.chained);
+  const geneTagVariantsFiltered = geneTagVariants.filter(d => d.chained);
+  const tagVariantIndexVariantStudiesFiltered = tagVariantIndexVariantStudies.filter(
+    d => d.chained
+  );
+
+  const isEmpty =
+    transformed.geneTagVariants.length === 0 &&
+    transformed.tagVariantIndexVariantStudies.length === 0;
+  const isEmptyFiltered =
+    filtered.geneTagVariants.length === 0 &&
+    filtered.tagVariantIndexVariantStudies.length === 0;
+
+  const rows = locusTable(
+    {
+      genes: genesFiltered,
+      tagVariants: tagVariantsFiltered,
+      indexVariants: indexVariantsFiltered,
+      studies: studiesFiltered,
+      geneTagVariants: geneTagVariantsFiltered,
+      tagVariantIndexVariantStudies: tagVariantIndexVariantStudiesFiltered,
+    },
+    lookups
+  );
+  let plot;
+  switch (scheme) {
+    case LOCUS_SCHEME.CHAINED:
+      plot = {
+        genes: genesFiltered,
+        tagVariants: tagVariantsFiltered,
+        indexVariants: indexVariantsFiltered,
+        studies: studiesFiltered,
+        geneTagVariants: geneTagVariantsFiltered,
+        tagVariantIndexVariantStudies: tagVariantIndexVariantStudiesFiltered,
+      };
+      break;
+    case LOCUS_SCHEME.ALL:
+      plot = {
+        genes,
+        tagVariants,
+        indexVariants,
+        studies,
+        geneTagVariants,
+        tagVariantIndexVariantStudies,
+      };
+      break;
+    case LOCUS_SCHEME.ALL_GENES:
+    default:
+      plot = {
+        genes,
+        tagVariants: tagVariantsFiltered,
+        indexVariants: indexVariantsFiltered,
+        studies: studiesFiltered,
+        geneTagVariants: geneTagVariantsFiltered,
+        tagVariantIndexVariantStudies: tagVariantIndexVariantStudiesFiltered,
+      };
+  }
+  return {
+    plot,
+    rows,
+    lookups,
+    isEmpty,
+    isEmptyFiltered,
+  };
+};
+
+export default locusScheme;

--- a/src/logic/locusScheme.js
+++ b/src/logic/locusScheme.js
@@ -21,15 +21,21 @@ const variantComparator = (a, b) => {
 
 const geneTagVariantComparator = (a, b) => {
   // render by ordering (chained, overallScore)
-  const scoreA = (a.chained ? 2 : 1) + a.overallScore;
-  const scoreB = (b.chained ? 2 : 1) + b.overallScore;
+  const scoreA = (a.chained ? 2 : 0) + a.overallScore;
+  const scoreB = (b.chained ? 2 : 0) + b.overallScore;
   return scoreA - scoreB;
 };
 
 const tagVariantIndexVariantStudyComparator = (a, b) => {
   // render by ordering (chained, finemapping, r2)
-  const scoreA = (a.chained ? 8 : 4) + (a.finemapping ? 2 : 1) + a.r2;
-  const scoreB = (b.chained ? 8 : 4) + (b.finemapping ? 2 : 1) + b.r2;
+  const scoreA =
+    (a.chained ? 8 : 4) +
+    (a.posteriorProbability ? 1 + a.posteriorProbability : 0) +
+    a.r2;
+  const scoreB =
+    (b.chained ? 8 : 4) +
+    (b.posteriorProbability ? 1 + b.posteriorProbability : 0) +
+    b.r2;
   return scoreA - scoreB;
 };
 

--- a/src/logic/locusScheme.js
+++ b/src/logic/locusScheme.js
@@ -11,6 +11,38 @@ export const LOCUS_SCHEME = {
   ALL_GENES: 3,
 };
 
+const geneTagVariantComparator = (a, b) => {
+  // render by ordering (chained, overallScore)
+  const scoreA = (a.chained ? 1 : 0) + a.overallScore;
+  const scoreB = (b.chained ? 1 : 0) + b.overallScore;
+  return scoreA - scoreB;
+  // if (a.chained && b.chained) {
+  //   return a.overallScore - b.overallScore;
+  // } else if (a.chained) {
+  //   return 1;
+  // } else if (b.chained) {
+  //   return -1;
+  // } else {
+  //   return a.overallScore - b.overallScore;
+  // }
+};
+
+const tagVariantIndexVariantStudyComparator = (a, b) => {
+  // render by ordering (chained, finemapping, r2)
+  const scoreA = (a.chained ? 2 : 0) + (a.finemapping ? 1 : 0) + a.r2;
+  const scoreB = (b.chained ? 2 : 0) + (b.finemapping ? 1 : 0) + b.r2;
+  return scoreA - scoreB;
+  // if (a.posteriorProbability && b.posteriorProbability) {
+  //   return a.r2 - b.r2;
+  // } else if (a.posteriorProbability) {
+  //   return 1;
+  // } else if (b.posteriorProbability) {
+  //   return -1;
+  // } else {
+  //   return a.r2 - b.r2;
+  // }
+};
+
 const locusScheme = ({
   scheme,
   data,
@@ -52,10 +84,12 @@ const locusScheme = ({
   const tagVariantsFiltered = tagVariants.filter(d => d.chained);
   const indexVariantsFiltered = indexVariants.filter(d => d.chained);
   const studiesFiltered = studies.filter(d => d.chained);
-  const geneTagVariantsFiltered = geneTagVariants.filter(d => d.chained);
-  const tagVariantIndexVariantStudiesFiltered = tagVariantIndexVariantStudies.filter(
-    d => d.chained
-  );
+  const geneTagVariantsFiltered = geneTagVariants
+    .filter(d => d.chained)
+    .sort(geneTagVariantComparator);
+  const tagVariantIndexVariantStudiesFiltered = tagVariantIndexVariantStudies
+    .filter(d => d.chained)
+    .sort(tagVariantIndexVariantStudyComparator);
 
   const isEmpty =
     transformed.geneTagVariants.length === 0 &&
@@ -88,13 +122,19 @@ const locusScheme = ({
       };
       break;
     case LOCUS_SCHEME.ALL:
+      const geneTagVariantsSorted = geneTagVariants.sort(
+        geneTagVariantComparator
+      );
+      const tagVariantIndexVariantStudiesSorted = tagVariantIndexVariantStudies.sort(
+        tagVariantIndexVariantStudyComparator
+      );
       plot = {
         genes,
         tagVariants,
         indexVariants,
         studies,
-        geneTagVariants,
-        tagVariantIndexVariantStudies,
+        geneTagVariants: geneTagVariantsSorted,
+        tagVariantIndexVariantStudies: tagVariantIndexVariantStudiesSorted,
       };
       break;
     case LOCUS_SCHEME.ALL_GENES:

--- a/src/logic/locusScheme.js
+++ b/src/logic/locusScheme.js
@@ -11,17 +11,25 @@ export const LOCUS_SCHEME = {
   ALL_GENES: 3,
 };
 
+const BIGGER_THAN_POSITION = 1000000000;
+const variantComparator = (a, b) => {
+  // render by ordering (chained, position)
+  const scoreA = (a.chained ? BIGGER_THAN_POSITION : 0) + a.position;
+  const scoreB = (b.chained ? BIGGER_THAN_POSITION : 0) + b.position;
+  return scoreA - scoreB;
+};
+
 const geneTagVariantComparator = (a, b) => {
   // render by ordering (chained, overallScore)
-  const scoreA = (a.chained ? 1 : 0) + a.overallScore;
-  const scoreB = (b.chained ? 1 : 0) + b.overallScore;
+  const scoreA = (a.chained ? 2 : 1) + a.overallScore;
+  const scoreB = (b.chained ? 2 : 1) + b.overallScore;
   return scoreA - scoreB;
 };
 
 const tagVariantIndexVariantStudyComparator = (a, b) => {
   // render by ordering (chained, finemapping, r2)
-  const scoreA = (a.chained ? 2 : 0) + (a.finemapping ? 1 : 0) + a.r2;
-  const scoreB = (b.chained ? 2 : 0) + (b.finemapping ? 1 : 0) + b.r2;
+  const scoreA = (a.chained ? 8 : 4) + (a.finemapping ? 2 : 1) + a.r2;
+  const scoreB = (b.chained ? 8 : 4) + (b.finemapping ? 2 : 1) + b.r2;
   return scoreA - scoreB;
 };
 
@@ -63,8 +71,12 @@ const locusScheme = ({
   } = chained;
 
   const genesFiltered = genes.filter(d => d.chained);
-  const tagVariantsFiltered = tagVariants.filter(d => d.chained);
-  const indexVariantsFiltered = indexVariants.filter(d => d.chained);
+  const tagVariantsFiltered = tagVariants
+    .filter(d => d.chained)
+    .sort(variantComparator);
+  const indexVariantsFiltered = indexVariants
+    .filter(d => d.chained)
+    .sort(variantComparator);
   const studiesFiltered = studies.filter(d => d.chained);
   const geneTagVariantsFiltered = geneTagVariants
     .filter(d => d.chained)
@@ -104,6 +116,8 @@ const locusScheme = ({
       };
       break;
     case LOCUS_SCHEME.ALL:
+      const tagVariantsSorted = tagVariants.sort(variantComparator);
+      const indexVariantsSorted = indexVariants.sort(variantComparator);
       const geneTagVariantsSorted = geneTagVariants.sort(
         geneTagVariantComparator
       );
@@ -112,8 +126,8 @@ const locusScheme = ({
       );
       plot = {
         genes,
-        tagVariants,
-        indexVariants,
+        tagVariants: tagVariantsSorted,
+        indexVariants: indexVariantsSorted,
         studies,
         geneTagVariants: geneTagVariantsSorted,
         tagVariantIndexVariantStudies: tagVariantIndexVariantStudiesSorted,

--- a/src/logic/locusSelected.js
+++ b/src/logic/locusSelected.js
@@ -1,0 +1,45 @@
+const locusSelected = ({
+  data,
+  selectedGenes,
+  selectedTagVariants,
+  selectedIndexVariants,
+  selectedStudies,
+}) => {
+  const {
+    genes,
+    tagVariants,
+    indexVariants,
+    studies,
+    geneTagVariants,
+    tagVariantIndexVariantStudies,
+  } = data;
+
+  // add selected field
+  let genesWithSelected = genes.map(d => ({
+    ...d,
+    selected: selectedGenes && selectedGenes.indexOf(d.id) >= 0,
+  }));
+  let tagVariantsWithSelected = tagVariants.map(d => ({
+    ...d,
+    selected: selectedTagVariants && selectedTagVariants.indexOf(d.id) >= 0,
+  }));
+  let indexVariantsWithSelected = indexVariants.map(d => ({
+    ...d,
+    selected: selectedIndexVariants && selectedIndexVariants.indexOf(d.id) >= 0,
+  }));
+  let studiesWithSelected = studies.map(d => ({
+    ...d,
+    selected: selectedStudies && selectedStudies.indexOf(d.studyId) >= 0,
+  }));
+
+  return {
+    genes: genesWithSelected,
+    tagVariants: tagVariantsWithSelected,
+    indexVariants: indexVariantsWithSelected,
+    studies: studiesWithSelected,
+    geneTagVariants,
+    tagVariantIndexVariantStudies,
+  };
+};
+
+export default locusSelected;

--- a/src/logic/locusTransform.js
+++ b/src/logic/locusTransform.js
@@ -1,0 +1,63 @@
+function locusTransform({ data, lookups }) {
+  const {
+    genes,
+    geneTagVariants,
+    tagVariantIndexVariantStudies,
+    ...rest
+  } = data;
+  const { geneDict, tagVariantDict, indexVariantDict, studyDict } = lookups;
+
+  // gene exons come as flat list, rendering expects list of pairs
+  const genesWithExonPairs = genes.map(d => ({
+    ...d,
+    exons: d.exons.reduce((result, value, index, array) => {
+      if (index % 2 === 0) {
+        result.push(array.slice(index, index + 2));
+      }
+      return result;
+    }, []),
+  }));
+
+  // geneTagVariants come with ids only, but need position info for gene and tagVariant
+  const geneTagVariantsWithPosition = geneTagVariants.map(d => ({
+    ...d,
+    geneTss: geneDict[d.geneId].tss,
+    tagVariantPosition: tagVariantDict[d.tagVariantId].position,
+  }));
+
+  // tagVariantIndexVariantStudies come with ids only, but need position info for tagVariant and indexVariant
+  const tagVariantIndexVariantStudiesWithPosition = tagVariantIndexVariantStudies
+    .map(d => ({
+      ...d,
+      tagVariantPosition: tagVariantDict[d.tagVariantId].position,
+      indexVariantPosition: indexVariantDict[d.indexVariantId].position,
+      traitReported: studyDict[d.studyId].traitReported,
+    }))
+    .sort((a, b) => {
+      // render finemapping on top
+      if (a.posteriorProbability && b.posteriorProbability) {
+        return a.r2 - b.r2;
+      } else if (a.posteriorProbability) {
+        return 1;
+      } else if (b.posteriorProbability) {
+        return -1;
+      } else {
+        return a.r2 - b.r2;
+      }
+    });
+
+  console.info(
+    `Rendering ${geneTagVariants.length} (G, TV)s and ${
+      tagVariantIndexVariantStudies.length
+    } (TV, IV, S)s`
+  );
+
+  return {
+    genes: genesWithExonPairs,
+    geneTagVariants: geneTagVariantsWithPosition,
+    tagVariantIndexVariantStudies: tagVariantIndexVariantStudiesWithPosition,
+    ...rest,
+  };
+}
+
+export default locusTransform;

--- a/src/logic/locusTransform.js
+++ b/src/logic/locusTransform.js
@@ -26,25 +26,14 @@ function locusTransform({ data, lookups }) {
   }));
 
   // tagVariantIndexVariantStudies come with ids only, but need position info for tagVariant and indexVariant
-  const tagVariantIndexVariantStudiesWithPosition = tagVariantIndexVariantStudies
-    .map(d => ({
+  const tagVariantIndexVariantStudiesWithPosition = tagVariantIndexVariantStudies.map(
+    d => ({
       ...d,
       tagVariantPosition: tagVariantDict[d.tagVariantId].position,
       indexVariantPosition: indexVariantDict[d.indexVariantId].position,
       traitReported: studyDict[d.studyId].traitReported,
-    }))
-    .sort((a, b) => {
-      // render finemapping on top
-      if (a.posteriorProbability && b.posteriorProbability) {
-        return a.r2 - b.r2;
-      } else if (a.posteriorProbability) {
-        return 1;
-      } else if (b.posteriorProbability) {
-        return -1;
-      } else {
-        return a.r2 - b.r2;
-      }
-    });
+    })
+  );
 
   console.info(
     `Rendering ${geneTagVariants.length} (G, TV)s and ${

--- a/src/pages/LocusPage.js
+++ b/src/pages/LocusPage.js
@@ -360,8 +360,8 @@ class LocusPage extends React.Component {
                       ) : (
                         <PlotContainerSection>
                           <FullWidthText>
-                            There are associations in this locus, but they are
-                            filtered out. Try removing some filters.
+                            There are associations in this locus, but none match
+                            your filters. Try removing some filters.
                           </FullWidthText>
                         </PlotContainerSection>
                       )
@@ -386,6 +386,7 @@ class LocusPage extends React.Component {
                       data={plot}
                       start={start}
                       end={end}
+                      showGeneVerticals={displayTypeValue === LOCUS_SCHEME.ALL}
                       selectedGenes={selectedGenes}
                       selectedTagVariants={selectedTagVariants}
                       selectedIndexVariants={selectedIndexVariants}


### PR DESCRIPTION
This PR:
* refactors the logic for massaging the raw locus data into gecko plot and table
* adds a toggle on `displayType` (selection only, selection + all genes, everything)

The refactoring means that the `LocusPage` calls `locusScheme`, which internally:
* adds a boolean `selected` field to entities (based on selection from url)
* adds gene/variant positional information to `geneTagVariants` and `tagVariantIndexVariantStudies`
* adds a boolean `chained` field to entities (based on indirect selection)
* outputs plot and table data (based on the `displayType`)