### PR TITLE
Display <pvalThreshold when pval is less than the threshold

### DIFF
--- a/src/components/AssociatedGenes.js
+++ b/src/components/AssociatedGenes.js
@@ -4,6 +4,8 @@ import * as d3 from 'd3';
 
 import { OtTable, Tabs, Tab, DataCircle, LabelHML, Tooltip } from 'ot-ui';
 
+import { pvalThreshold } from '../constants';
+
 const OVERVIEW = 'overview';
 
 const radiusScale = d3
@@ -152,9 +154,11 @@ const getTissueColumns = (genesForVariantSchema, genesForVariant, sourceId) => {
               const qtlColor = beta > 0 ? 'red' : 'blue';
               return (
                 <Tooltip
-                  title={`Beta: ${beta.toPrecision(3)} pval: ${pval.toPrecision(
-                    3
-                  )}`}
+                  title={`Beta: ${beta.toPrecision(3)} pval: ${
+                    pval < pvalThreshold
+                      ? `<${pvalThreshold}`
+                      : pval.toPrecision(3)
+                  }`}
                 >
                   <span>
                     <DataCircle radius={qtlRadius} colorScheme={qtlColor} />

--- a/src/components/AssociatedIndexVariantsTable.js
+++ b/src/components/AssociatedIndexVariantsTable.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { OtTable, commaSeparate } from 'ot-ui';
 
+import { pvalThreshold } from '../constants';
+
 const tableColumns = variantId => [
   {
     id: 'indexVariantId',
@@ -32,7 +34,10 @@ const tableColumns = variantId => [
   {
     id: 'pval',
     label: 'Lead Variant P-value',
-    renderCell: rowData => rowData.pval.toPrecision(3),
+    renderCell: rowData =>
+      rowData.pval < pvalThreshold
+        ? `<${pvalThreshold}`
+        : rowData.pval.toPrecision(3),
   },
   {
     id: 'pmid',

--- a/src/components/AssociatedTagVariantsTable.js
+++ b/src/components/AssociatedTagVariantsTable.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { OtTable, commaSeparate } from 'ot-ui';
 
+import { pvalThreshold } from '../constants';
+
 const tableColumns = variantId => [
   {
     id: 'leadVariant',
@@ -32,7 +34,10 @@ const tableColumns = variantId => [
   {
     id: 'pval',
     label: 'Lead Variant P-value',
-    renderCell: rowData => rowData.pval.toPrecision(3),
+    renderCell: rowData =>
+      rowData.pval < pvalThreshold
+        ? `<${pvalThreshold}`
+        : rowData.pval.toPrecision(3),
   },
   {
     id: 'pmid',

--- a/src/components/LocusTable.js
+++ b/src/components/LocusTable.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { OtTable } from 'ot-ui';
 
+import { pvalThreshold } from '../constants';
+
 export const tableColumns = [
   {
     id: 'studyId',
@@ -43,7 +45,10 @@ export const tableColumns = [
   {
     id: 'pval',
     label: 'Lead Variant P-value',
-    renderCell: rowData => rowData.pval.toPrecision(3),
+    renderCell: rowData =>
+      rowData.pval < pvalThreshold
+        ? `<${pvalThreshold}`
+        : rowData.pval.toPrecision(3),
   },
   {
     id: 'method',

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -5,6 +5,7 @@ import { OtTable, commaSeparate } from 'ot-ui';
 import { getCytoband } from 'ot-charts';
 
 import LocusLink from './LocusLink';
+import { pvalThreshold } from '../constants';
 
 // this maps X, Y, and MT chromosomes to relative positions
 // for sorting
@@ -69,7 +70,10 @@ export const tableColumns = studyId => [
   {
     id: 'pval',
     label: 'P-value',
-    renderCell: rowData => rowData.pval.toPrecision(3),
+    renderCell: rowData =>
+      rowData.pval < pvalThreshold
+        ? `<${pvalThreshold}`
+        : rowData.pval.toPrecision(3),
   },
   {
     id: 'credibleSetSize',

--- a/src/components/PheWASTable.js
+++ b/src/components/PheWASTable.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { OtTable, commaSeparate } from 'ot-ui';
 
 import LocusLink from './LocusLink';
+import { pvalThreshold } from '../constants';
 
 export const tableColumns = ({
   variantId,
@@ -25,7 +26,10 @@ export const tableColumns = ({
   {
     id: 'pval',
     label: 'P-value',
-    renderCell: rowData => rowData.pval.toPrecision(3),
+    renderCell: rowData =>
+      rowData.pval < pvalThreshold
+        ? `<${pvalThreshold}`
+        : rowData.pval.toPrecision(3),
   },
   {
     id: 'beta',

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+export const pvalThreshold = 4.94e-322;


### PR DESCRIPTION
This PR displays the pval as `pval<4.94e-322` when the pval is less than 4.94e-322 in the following places of the genetics portal:

Variant Page
- [x] Assigned genes tabs, in the circle tooltips for the qtl tissues
- [x] PheWAS plot tooltips
- [x] PheWAS table p-value column
- [x] GWAS lead variant table p-value column
- [x] Tag variant table p-value column

Study Page
- [x] Manhattan plot tooltips
- [x] Manhattan table p-value column

Locus Page
- [x] Locus table p-value column
