### PR TITLE
Add tooltip to gene column in locus table

### DIFF
--- a/src/components/LocusTable.js
+++ b/src/components/LocusTable.js
@@ -38,6 +38,7 @@ export const tableColumns = [
   {
     id: 'geneId',
     label: 'Gene',
+    tooltip: 'Gene functionally implicated by the tag variant',
     renderCell: rowData => (
       <Link to={`/gene/${rowData.geneId}`}>{rowData.gene.symbol}</Link>
     ),


### PR DESCRIPTION
Gecko Table - add the following tooltip to 'Gene': 'Gene functionally implicated by the tag variant'