### PR TITLE
Use loading and error states of `ot-ui` components

### DIFF
--- a/src/components/AssociatedIndexVariantsTable.js
+++ b/src/components/AssociatedIndexVariantsTable.js
@@ -85,6 +85,8 @@ const AssociatedIndexVariantsTable = ({
   variantId,
 }) => (
   <OtTable
+    loading={loading}
+    error={error}
     columns={tableColumns(variantId)}
     data={data}
     sortBy="pval"

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -79,6 +79,8 @@ const AssociatedStudiesTable = ({
   position,
 }) => (
   <OtTable
+    loading={loading}
+    error={error}
     columns={tableColumns(geneId, chromosome, position)}
     data={data}
     sortBy="nInitial"

--- a/src/components/AssociatedTagVariantsTable.js
+++ b/src/components/AssociatedTagVariantsTable.js
@@ -90,6 +90,8 @@ const AssociatedTagVariantsTable = ({
   variantId,
 }) => (
   <OtTable
+    loading={loading}
+    error={error}
     columns={tableColumns(variantId)}
     data={data}
     sortBy="pval"

--- a/src/components/LocusTable.js
+++ b/src/components/LocusTable.js
@@ -84,9 +84,11 @@ export const tableColumns = [
   },
 ];
 
-function LocusTable({ data, filenameStem }) {
+function LocusTable({ loading, error, data, filenameStem }) {
   return (
     <OtTable
+      loading={loading}
+      error={error}
       columns={tableColumns}
       data={data}
       sortBy="pval"

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -83,9 +83,11 @@ export const tableColumns = studyId => [
   },
 ];
 
-function ManhattanTable({ data, studyId, filenameStem }) {
+function ManhattanTable({ loading, error, data, studyId, filenameStem }) {
   return (
     <OtTable
+      loading={loading}
+      error={error}
       columns={tableColumns(studyId)}
       data={data}
       sortBy="pval"

--- a/src/components/ManhattansTable.js
+++ b/src/components/ManhattansTable.js
@@ -80,6 +80,8 @@ export const tableColumns = ({ onDeleteStudy, onClickIntersectionLocus }) => [
 ];
 
 function ManhattansTable({
+  loading,
+  error,
   select,
   studies,
   rootStudy,
@@ -91,6 +93,8 @@ function ManhattansTable({
   const columnsFixed = tableColumns({ onClickIntersectionLocus });
   return (
     <OtTable
+      loading={loading}
+      error={error}
       left={select}
       columns={columns}
       data={studies}

--- a/src/components/ManhattansVariantsTable.js
+++ b/src/components/ManhattansVariantsTable.js
@@ -62,9 +62,17 @@ const tableColumns = studyIds => [
   },
 ];
 
-function ManhattansVariantsTable({ data, studyIds, filenameStem }) {
+function ManhattansVariantsTable({
+  loading,
+  error,
+  data,
+  studyIds,
+  filenameStem,
+}) {
   return (
     <OtTable
+      loading={loading}
+      error={error}
       columns={tableColumns(studyIds)}
       data={data}
       sortBy="indexVariantId"

--- a/src/components/PheWASTable.js
+++ b/src/components/PheWASTable.js
@@ -83,6 +83,8 @@ export const tableColumns = ({
 ];
 
 function PheWASTable({
+  loading,
+  error,
   associations,
   variantId,
   chromosome,
@@ -92,6 +94,8 @@ function PheWASTable({
 }) {
   return (
     <OtTable
+      loading={loading}
+      error={error}
       columns={tableColumns({
         variantId,
         chromosome,

--- a/src/components/StudyInfo.js
+++ b/src/components/StudyInfo.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const StudyInfo = ({ studyInfo }) => {
+  return (
+    <div>
+      {`${studyInfo.pubAuthor} (${new Date(studyInfo.pubDate).getFullYear()}) `}
+      {studyInfo.pubJournal && <em>{`${studyInfo.pubJournal} `}</em>}
+      {studyInfo.pmid && (
+        <a
+          href={`http://europepmc.org/abstract/med/${studyInfo.pmid}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {studyInfo.pmid}
+        </a>
+      )}
+    </div>
+  );
+};
+
+export default StudyInfo;

--- a/src/components/StudySize.js
+++ b/src/components/StudySize.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { commaSeparate } from 'ot-ui';
+
+const StudySize = ({ studyInfo }) => {
+  const { nInitial, nReplication, nCases } = studyInfo;
+  return (
+    <div>
+      {nInitial !== null && `N Study: ${commaSeparate(nInitial)}`}{' '}
+      {nReplication !== null && `N Replication: ${commaSeparate(nReplication)}`}{' '}
+      {nCases !== null && `N Cases: ${commaSeparate(nCases)}`}
+    </div>
+  );
+};
+
+export default StudySize;

--- a/src/logic/locusScheme.js
+++ b/src/logic/locusScheme.js
@@ -45,6 +45,21 @@ const tagVariantIndexVariantStudyComparator = (a, b) => {
   return scoreA - scoreB;
 };
 
+const EMPTY_PLOT = {
+  genes: [],
+  tagVariants: [],
+  indexVariants: [],
+  studies: [],
+  geneTagVariants: [],
+  tagVariantIndexVariantStudies: [],
+};
+const EMPTY_LOOKUPS = {
+  geneDict: {},
+  tagVariantDict: {},
+  indexVariantDict: {},
+  studyDict: {},
+};
+
 const locusScheme = ({
   scheme,
   finemappingOnly,
@@ -54,6 +69,16 @@ const locusScheme = ({
   selectedIndexVariants,
   selectedStudies,
 }) => {
+  if (!data) {
+    return {
+      plot: EMPTY_PLOT,
+      rows: [],
+      lookups: EMPTY_LOOKUPS,
+      isEmpty: true,
+      isEmptyFiltered: true,
+    };
+  }
+
   const lookups = locusLookups(data);
   const finemapping = locusFinemapping({ data, finemappingOnly });
   const selected = locusSelected({

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -35,101 +35,122 @@ const SEARCH_QUERY = gql`
   }
 `;
 
+function hasGeneData(data, geneId) {
+  return (
+    data &&
+    data.search &&
+    data.search.genes &&
+    data.search.genes.length === 1 &&
+    data.search.genes[0].id === geneId
+  );
+}
+
+function geneData(data) {
+  return data.search.genes[0];
+}
+
+function hasAssociatedStudies(data) {
+  return data && data.studiesForGene;
+}
+
 const GenePage = ({ match }) => {
   const { geneId } = match.params;
   return (
     <BasePage>
       <Query query={SEARCH_QUERY} variables={{ geneId }}>
         {({ loading, error, data }) => {
-          if (loading) {
-            return <span>Fetching gene location and redirecting...</span>;
-          } else if (
-            data &&
-            data.search &&
-            data.search.genes &&
-            data.search.genes.length === 1 &&
-            data.studiesForGene
-          ) {
-            const { chromosome, start, end, symbol } = data.search.genes[0];
-            const position = Math.floor((start + end) / 2);
-            return (
-              <React.Fragment>
-                <Helmet>
-                  <title>{symbol}</title>
-                </Helmet>
-                <PageTitle>{symbol}</PageTitle>
-                <SubHeading
-                  left={`${chromosome}:${commaSeparate(start)}-${commaSeparate(
-                    end
-                  )} `}
-                />
+          const isValidGene = hasGeneData(data, geneId);
+          const gene = isValidGene ? geneData(data) : {};
+          const associatedStudies =
+            isValidGene && hasAssociatedStudies(data)
+              ? data.studiesForGene.map(d => d.study)
+              : [];
 
-                <SubHeading
-                  left={
+          const { chromosome, start, end, symbol } = gene;
+          return (
+            <React.Fragment>
+              <Helmet>
+                <title>{symbol}</title>
+              </Helmet>
+              <PageTitle>
+                {symbol} <span style={{ fontSize: '0.8rem' }}>{geneId}</span>
+              </PageTitle>
+              <SubHeading
+                left={
+                  isValidGene
+                    ? `${chromosome}:${commaSeparate(start)}-${commaSeparate(
+                        end
+                      )} `
+                    : null
+                }
+              />
+              <SubHeading
+                left={
+                  isValidGene ? (
                     <LocusLink
                       chromosome={chromosome}
-                      position={position}
+                      position={Math.round((start + end) / 2)}
                       selectedGenes={[geneId]}
                     >
                       View locus
                     </LocusLink>
-                  }
-                />
-                <SectionHeading heading="Useful links" />
-                <SubHeading
-                  left={
-                    <Fragment>
-                      <a
-                        href={`https://www.targetvalidation.org/target/${geneId}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        Open Targets Platform
-                      </a>
-                      <br />
-                      <a
-                        href={`https://www.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=${geneId}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        Ensembl
-                      </a>
-                      <br />
-                      <a
-                        href={`https://gtexportal.org/home/eqtls/byGene?geneId=${symbol}&tissueName=All`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        GTEx
-                      </a>
-                    </Fragment>
-                  }
-                />
-                <SectionHeading
-                  heading={`Associated studies`}
-                  subheading={`Which studies are associated with ${symbol}?`}
-                  entities={[
-                    {
-                      type: 'study',
-                      fixed: false,
-                    },
-                    {
-                      type: 'gene',
-                      fixed: true,
-                    },
-                  ]}
-                />
-                <AssociatedStudiesTable
-                  data={data.studiesForGene.map(d => d.study)}
-                  geneId={geneId}
-                  chromosome={chromosome}
-                  position={Math.round((start + end) / 2)}
-                />
-              </React.Fragment>
-            );
-          } else {
-            return <span>Could not find gene.</span>;
-          }
+                  ) : null
+                }
+              />
+              <SectionHeading heading="Useful links" />
+              <SubHeading
+                left={
+                  <Fragment>
+                    <a
+                      href={`https://www.targetvalidation.org/target/${geneId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Open Targets Platform
+                    </a>
+                    <br />
+                    <a
+                      href={`https://www.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=${geneId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Ensembl
+                    </a>
+                    <br />
+                    <a
+                      href={`https://gtexportal.org/home/eqtls/byGene?geneId=${symbol}&tissueName=All`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      GTEx
+                    </a>
+                  </Fragment>
+                }
+              />
+              <SectionHeading
+                heading={`Associated studies`}
+                subheading={`Which studies are associated with ${symbol}?`}
+                entities={[
+                  {
+                    type: 'study',
+                    fixed: false,
+                  },
+                  {
+                    type: 'gene',
+                    fixed: true,
+                  },
+                ]}
+              />
+              <AssociatedStudiesTable
+                loading={loading}
+                error={error}
+                data={associatedStudies}
+                geneId={geneId}
+                chromosome={chromosome}
+                position={Math.round((start + end) / 2)}
+              />
+            </React.Fragment>
+          );
         }}
       </Query>
     </BasePage>

--- a/src/pages/LocusPage.js
+++ b/src/pages/LocusPage.js
@@ -310,136 +310,136 @@ class LocusPage extends React.Component {
           fetchPolicy="network-only"
         >
           {({ loading, error, data }) => {
-            if (hasData(data)) {
-              const {
-                lookups,
-                plot,
-                rows,
-                isEmpty,
-                isEmptyFiltered,
-              } = locusScheme({
-                scheme: displayTypeValue,
-                finemappingOnly:
-                  displayFinemappingValue ===
-                  LOCUS_FINEMAPPING.FINEMAPPING_ONLY,
-                data: data.gecko,
-                selectedGenes,
-                selectedTagVariants,
-                selectedIndexVariants,
-                selectedStudies,
-              });
-              return (
-                <React.Fragment>
-                  <PlotContainer
-                    left={
-                      <BrowserControls
-                        handleZoomIn={this.handleZoomIn}
-                        handleZoomOut={this.handleZoomOut}
-                        handlePanLeft={this.handlePanLeft}
-                        handlePanRight={this.handlePanRight}
-                        handleDisplayTypeChange={this.handleDisplayTypeChange}
-                        handleDisplayFinemappingChange={
-                          this.handleDisplayFinemappingChange
-                        }
-                        displayTypeValue={displayTypeValue}
-                        displayTypeOptions={[
-                          {
-                            value: LOCUS_SCHEME.ALL_GENES,
-                            label: 'Show selection and all genes',
-                          },
-                          {
-                            value: LOCUS_SCHEME.CHAINED,
-                            label: 'Show selection',
-                          },
-                          {
-                            value: LOCUS_SCHEME.ALL,
-                            label: 'Show all data in locus',
-                          },
-                        ]}
-                        displayFinemappingValue={displayFinemappingValue}
-                        displayFinemappingOptions={[
-                          {
-                            value: LOCUS_FINEMAPPING.ALL,
-                            label: 'Show expansion by LD and finemapping',
-                          },
-                          {
-                            value: LOCUS_FINEMAPPING.FINEMAPPING_ONLY,
-                            label: 'Show expansion by finemapping only',
-                          },
-                        ]}
-                      />
-                    }
-                    right={
-                      <Button
-                        variant="outlined"
-                        onClick={() => {
-                          downloadPNG({
-                            canvasNode: findDOMNode(
-                              geckoPlot.current
-                            ).querySelector('canvas'),
-                            filenameStem: locationString,
-                          });
-                        }}
-                      >
-                        PNG
-                      </Button>
-                    }
-                  >
-                    {isEmptyFiltered ? (
-                      isEmpty ? (
-                        <PlotContainerSection>
-                          <FullWidthText>
-                            There are no associations in this locus.
-                          </FullWidthText>
-                        </PlotContainerSection>
-                      ) : (
-                        <PlotContainerSection>
-                          <FullWidthText>
-                            There are associations in this locus, but none match
-                            your filters. Try removing some filters.
-                          </FullWidthText>
-                        </PlotContainerSection>
-                      )
-                    ) : null}
-                    <PlotContainerSection>
-                      <LocusSelection
-                        {...{
-                          selectedGenes,
-                          selectedTagVariants,
-                          selectedIndexVariants,
-                          selectedStudies,
-                        }}
-                        lookups={lookups}
-                        handleDeleteGene={this.handleDeleteGene}
-                        handleDeleteTagVariant={this.handleDeleteTagVariant}
-                        handleDeleteIndexVariant={this.handleDeleteIndexVariant}
-                        handleDeleteStudy={this.handleDeleteStudy}
-                      />
-                    </PlotContainerSection>
-
-                    <Gecko
-                      ref={geckoPlot}
-                      data={plot}
-                      start={start}
-                      end={end}
-                      showGeneVerticals={displayTypeValue === LOCUS_SCHEME.ALL}
-                      selectedGenes={selectedGenes}
-                      selectedTagVariants={selectedTagVariants}
-                      selectedIndexVariants={selectedIndexVariants}
-                      selectedStudies={selectedStudies}
-                      handleClick={this.handleClick}
-                      handleMousemove={this.handleMousemove}
+            const isValidLocus = hasData(data);
+            const {
+              lookups,
+              plot,
+              rows,
+              isEmpty,
+              isEmptyFiltered,
+            } = locusScheme({
+              scheme: displayTypeValue,
+              finemappingOnly:
+                displayFinemappingValue === LOCUS_FINEMAPPING.FINEMAPPING_ONLY,
+              data: isValidLocus ? data.gecko : null,
+              selectedGenes,
+              selectedTagVariants,
+              selectedIndexVariants,
+              selectedStudies,
+            });
+            return (
+              <React.Fragment>
+                <PlotContainer
+                  loading={loading}
+                  error={error}
+                  left={
+                    <BrowserControls
+                      handleZoomIn={this.handleZoomIn}
+                      handleZoomOut={this.handleZoomOut}
+                      handlePanLeft={this.handlePanLeft}
+                      handlePanRight={this.handlePanRight}
+                      handleDisplayTypeChange={this.handleDisplayTypeChange}
+                      handleDisplayFinemappingChange={
+                        this.handleDisplayFinemappingChange
+                      }
+                      displayTypeValue={displayTypeValue}
+                      displayTypeOptions={[
+                        {
+                          value: LOCUS_SCHEME.ALL_GENES,
+                          label: 'Show selection and all genes',
+                        },
+                        {
+                          value: LOCUS_SCHEME.CHAINED,
+                          label: 'Show selection',
+                        },
+                        {
+                          value: LOCUS_SCHEME.ALL,
+                          label: 'Show all data in locus',
+                        },
+                      ]}
+                      displayFinemappingValue={displayFinemappingValue}
+                      displayFinemappingOptions={[
+                        {
+                          value: LOCUS_FINEMAPPING.ALL,
+                          label: 'Show expansion by LD and finemapping',
+                        },
+                        {
+                          value: LOCUS_FINEMAPPING.FINEMAPPING_ONLY,
+                          label: 'Show expansion by finemapping only',
+                        },
+                      ]}
                     />
-                  </PlotContainer>
-                  <LocusTable
-                    data={rows}
-                    filenameStem={`${chromosome}-${start}-${end}-locus`}
+                  }
+                  right={
+                    <Button
+                      variant="outlined"
+                      onClick={() => {
+                        downloadPNG({
+                          canvasNode: findDOMNode(
+                            geckoPlot.current
+                          ).querySelector('canvas'),
+                          filenameStem: locationString,
+                        });
+                      }}
+                    >
+                      PNG
+                    </Button>
+                  }
+                >
+                  {isEmptyFiltered ? (
+                    isEmpty ? (
+                      <PlotContainerSection>
+                        <FullWidthText>
+                          There are no associations in this locus.
+                        </FullWidthText>
+                      </PlotContainerSection>
+                    ) : (
+                      <PlotContainerSection>
+                        <FullWidthText>
+                          There are associations in this locus, but none match
+                          your filters. Try removing some filters.
+                        </FullWidthText>
+                      </PlotContainerSection>
+                    )
+                  ) : null}
+                  <PlotContainerSection>
+                    <LocusSelection
+                      {...{
+                        selectedGenes,
+                        selectedTagVariants,
+                        selectedIndexVariants,
+                        selectedStudies,
+                      }}
+                      lookups={lookups}
+                      handleDeleteGene={this.handleDeleteGene}
+                      handleDeleteTagVariant={this.handleDeleteTagVariant}
+                      handleDeleteIndexVariant={this.handleDeleteIndexVariant}
+                      handleDeleteStudy={this.handleDeleteStudy}
+                    />
+                  </PlotContainerSection>
+
+                  <Gecko
+                    ref={geckoPlot}
+                    data={plot}
+                    start={start}
+                    end={end}
+                    showGeneVerticals={displayTypeValue === LOCUS_SCHEME.ALL}
+                    selectedGenes={selectedGenes}
+                    selectedTagVariants={selectedTagVariants}
+                    selectedIndexVariants={selectedIndexVariants}
+                    selectedStudies={selectedStudies}
+                    handleClick={this.handleClick}
+                    handleMousemove={this.handleMousemove}
                   />
-                </React.Fragment>
-              );
-            } else {
-              return null;
-            }
+                </PlotContainer>
+                <LocusTable
+                  loading={loading}
+                  error={error}
+                  data={rows}
+                  filenameStem={`${chromosome}-${start}-${end}-locus`}
+                />
+              </React.Fragment>
+            );
           }}
         </Query>
       </BasePage>

--- a/src/pages/StudiesPage.js
+++ b/src/pages/StudiesPage.js
@@ -244,7 +244,7 @@ function getStudyInfo(data) {
   return data.studyInfo;
 }
 
-function transformManhattansVariants(data, variantIntersectionSet) {
+function getOverlappingVariants(data, variantIntersectionSet) {
   if (!hasManhattan(data)) {
     return [];
   }
@@ -348,7 +348,7 @@ class StudiesPage extends React.Component {
               rootStudy,
               studies,
             } = getStudiesTableData(data, studyId, studyIds);
-            const manhattansVariants = transformManhattansVariants(
+            const overlappingVariants = getOverlappingVariants(
               data,
               variantIntersectionSet
             );
@@ -419,7 +419,7 @@ class StudiesPage extends React.Component {
                 <ManhattansVariantsTable
                   loading={loading}
                   error={error}
-                  data={manhattansVariants}
+                  data={overlappingVariants}
                   studyIds={[studyId, ...studyIds]}
                   filenameStem={`intersecting-independently-associated-loci`}
                 />

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -3,7 +3,6 @@ import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
-import { commaSeparate } from 'ot-ui';
 
 import {
   PageTitle,
@@ -18,6 +17,8 @@ import { Manhattan, withTooltip } from 'ot-charts';
 import BasePage from './BasePage';
 import ManhattanTable, { tableColumns } from '../components/ManhattanTable';
 import ScrollToTop from '../components/ScrollToTop';
+import StudyInfo from '../components/StudyInfo';
+import StudySize from '../components/StudySize';
 
 const SIGNIFICANCE = 5e-8;
 
@@ -90,35 +91,6 @@ const manhattanQuery = gql`
     }
   }
 `;
-
-const StudyInfo = ({ studyInfo }) => {
-  return (
-    <div>
-      {`${studyInfo.pubAuthor} (${new Date(studyInfo.pubDate).getFullYear()}) `}
-      {studyInfo.pubJournal && <em>{`${studyInfo.pubJournal} `}</em>}
-      {studyInfo.pmid && (
-        <a
-          href={`http://europepmc.org/abstract/med/${studyInfo.pmid}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {studyInfo.pmid}
-        </a>
-      )}
-    </div>
-  );
-};
-
-const StudySize = ({ studyInfo }) => {
-  const { nInitial, nReplication, nCases } = studyInfo;
-  return (
-    <div>
-      {nInitial !== null && `N Study: ${commaSeparate(nInitial)}`}{' '}
-      {nReplication !== null && `N Replication: ${commaSeparate(nReplication)}`}{' '}
-      {nCases !== null && `N Cases: ${commaSeparate(nCases)}`}
-    </div>
-  );
-};
 
 class StudyPage extends React.Component {
   render() {

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -33,11 +33,13 @@ function hasAssociations(data) {
 function transformAssociations(data) {
   return {
     associations: data.manhattan.associations.map(d => {
-      const { variantId, variantRsId, ...rest } = d;
+      const { variant, ...rest } = d;
       return {
         ...rest,
-        indexVariantId: variantId,
-        indexVariantRsId: variantRsId,
+        indexVariantId: variant.id,
+        indexVariantRsId: variant.rsId,
+        chromosome: variant.chromosome,
+        position: variant.position,
       };
     }),
   };
@@ -68,11 +70,13 @@ const manhattanQuery = gql`
     }
     manhattan(studyId: $studyId) {
       associations {
-        variantId
-        variantRsId
+        variant {
+          id
+          rsId
+          chromosome
+          position
+        }
         pval
-        chromosome
-        position
         credibleSetSize
         ldSetSize
         bestGenes {


### PR DESCRIPTION
This PR:
* passes `loading` and `error` props to `OtTable` components where appropriate
* updates the `manhattan(studyId)` query following breaking changes