### PR TITLE
Add gnomAD links

### DIFF
--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -50,6 +50,15 @@ const styles = theme => {
       height: '100%',
       padding: theme.sectionPadding,
     },
+    geneSymbol: {
+      display: 'inline-block',
+    },
+    gnomadLink: {
+      position: 'relative',
+      marginLeft: '5px',
+      bottom: '8px',
+      textDecoration: 'none',
+    },
     locusLinkButton: {
       width: '240px',
       height: '60px',
@@ -201,7 +210,19 @@ class GenePage extends React.Component {
                     <Paper className={classes.section}>
                       <Grid container justify="space-between">
                         <Grid item>
-                          <Typography variant="display1">{symbol}</Typography>
+                          <Typography
+                            className={classes.geneSymbol}
+                            variant="display1"
+                          >
+                            {symbol}
+                          </Typography>
+                          <a
+                            className={classes.gnomadLink}
+                            href={`http://gnomad.broadinstitute.org/gene/${geneId}`}
+                            target="_blank"
+                          >
+                            <Button variant="outlined">gnomAD</Button>
+                          </a>
                           <Typography variant="subheading">
                             {chromosome}:{commaSeparate(start)}-
                             {commaSeparate(end)}
@@ -305,18 +326,6 @@ class GenePage extends React.Component {
                           >
                             <Button variant="outlined">
                               Ensembl <LinkIcon />
-                            </Button>
-                          </a>
-                        </Grid>
-                        <Grid item>
-                          <a
-                            className={classes.link}
-                            href={`http://exac.broadinstitute.org/gene/${geneId}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            <Button variant="outlined">
-                              ExAC <LinkIcon />
                             </Button>
                           </a>
                         </Grid>

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -94,7 +94,7 @@ const styles = theme => {
     headerSection: {
       padding: theme.sectionPadding,
     },
-    ensemblLink: {
+    link: {
       marginLeft: '5px',
       position: 'relative',
       bottom: '8px',
@@ -205,13 +205,23 @@ class VariantPage extends React.Component {
                         {variantInfo.rsId}
                       </Typography>
                       <a
-                        className={classes.ensemblLink}
+                        className={classes.link}
                         href={`http://grch37.ensembl.org/Homo_sapiens/Variation/Explore?v=${
                           variantInfo.rsId
                         }`}
                         target="_blank"
                       >
                         <Button variant="outlined">Ensembl</Button>
+                      </a>
+                      <a
+                        className={classes.link}
+                        href={`http://gnomad.broadinstitute.org/variant/${variantId.replace(
+                          /_/g,
+                          '-'
+                        )}`}
+                        target="_blank"
+                      >
+                        <Button variant="outlined">gnomAD</Button>
                       </a>
                     </Grid>
                   </Grid>


### PR DESCRIPTION
This PR:

- Adds links to gnomAD from the top of the Gene page and Variant page
- Removes the ExAC link from the `Other links` section in the Gene page.

Related issue: https://github.com/opentargets/genetics/issues/12