### PR TITLE
Update material ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# for vim users
+*.swp

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "email": "support@targetvalidation.org"
   },
   "dependencies": {
-    "@material-ui/core": "^1.4.3",
-    "@material-ui/icons": "^2.0.2",
+    "@material-ui/core": "^3.4.0",
+    "@material-ui/icons": "^3.0.1",
     "apollo-cache-inmemory": "^1.2.5",
     "apollo-client": "^2.3.5",
     "apollo-link-http": "^1.5.4",

--- a/src/components/LocusSelection.js
+++ b/src/components/LocusSelection.js
@@ -27,7 +27,7 @@ const LocusSelection = ({
     <div>
       {noSelection ? (
         <div style={{ width: '100%', textAlign: 'center' }}>
-          <Typography variant="subheading">No filters applied</Typography>
+          <Typography variant="subtitle1">No filters applied</Typography>
         </div>
       ) : null}
       {selectedStudies

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -60,7 +60,7 @@ const styles = theme => {
       textDecoration: 'none',
     },
     locusLinkButton: {
-      width: '240px',
+      width: '248px',
       height: '60px',
     },
     locusIcon: {
@@ -212,7 +212,8 @@ class GenePage extends React.Component {
                         <Grid item>
                           <Typography
                             className={classes.geneSymbol}
-                            variant="display1"
+                            variant="h4"
+                            color="textSecondary"
                           >
                             {symbol}
                           </Typography>
@@ -223,7 +224,7 @@ class GenePage extends React.Component {
                           >
                             <Button variant="outlined">gnomAD</Button>
                           </a>
-                          <Typography variant="subheading">
+                          <Typography variant="subtitle1">
                             {chromosome}:{commaSeparate(start)}-
                             {commaSeparate(end)}
                           </Typography>
@@ -249,7 +250,7 @@ class GenePage extends React.Component {
                 <Grid container justify="space-between" spacing={8}>
                   <Grid item sm={12} md={8}>
                     <Paper className={classes.section}>
-                      <Typography variant="subheading">
+                      <Typography variant="subtitle1">
                         Information about {symbol} from the Open Targets
                         Platform
                       </Typography>

--- a/src/pages/LocusPage.js
+++ b/src/pages/LocusPage.js
@@ -35,7 +35,7 @@ function hasData(data) {
 
 const FullWidthText = ({ children }) => (
   <div style={{ width: '100%', textAlign: 'center' }}>
-    <Typography variant="subheading">{children}</Typography>
+    <Typography variant="subtitle1">{children}</Typography>
   </div>
 );
 
@@ -328,7 +328,9 @@ class LocusPage extends React.Component {
           <title>{locationString}</title>
         </Helmet>
         <Paper className={classes.section}>
-          <Typography variant="display1">Locus {locationString}</Typography>
+          <Typography variant="h4" color="textSecondary">
+            Locus {locationString}
+          </Typography>
         </Paper>
         <SectionHeading
           heading="Associations"

--- a/src/pages/StudiesPage.js
+++ b/src/pages/StudiesPage.js
@@ -296,20 +296,20 @@ class StudiesPage extends React.Component {
             return (
               <Fragment>
                 <Paper className={classes.section}>
-                  <Typography variant="display1">
+                  <Typography variant="h4" color="textSecondary">
                     {studyInfo.traitReported}
                   </Typography>
                   <Grid container justify="space-between">
                     <Grid item>
                       {isStudyWithInfo ? (
-                        <Typography variant="subheading">
+                        <Typography variant="subtitle1">
                           <StudyInfo studyInfo={data.studyInfo} />
                         </Typography>
                       ) : null}
                     </Grid>
                     <Grid item>
                       {isStudyWithInfo ? (
-                        <Typography variant="subheading">
+                        <Typography variant="subtitle1">
                           <StudySize studyInfo={data.studyInfo} />
                         </Typography>
                       ) : null}

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -110,20 +110,20 @@ class StudyPage extends React.Component {
             return (
               <Fragment>
                 <Paper className={classes.section}>
-                  <Typography variant="display1">
+                  <Typography variant="h4" color="textSecondary">
                     {isStudyWithInfo ? data.studyInfo.traitReported : null}
                   </Typography>
                   <Grid container justify="space-between">
                     <Grid item>
                       {isStudyWithInfo ? (
-                        <Typography variant="subheading">
+                        <Typography variant="subtitle1">
                           <StudyInfo studyInfo={data.studyInfo} />
                         </Typography>
                       ) : null}
                     </Grid>
                     <Grid item>
                       {isStudyWithInfo ? (
-                        <Typography variant="subheading">
+                        <Typography variant="subtitle1">
                           <StudySize studyInfo={data.studyInfo} />
                         </Typography>
                       ) : null}

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -194,12 +194,16 @@ class VariantPage extends React.Component {
                 <Paper className={classes.headerSection}>
                   <Grid container>
                     <Grid item>
-                      <Typography className={classes.header} variant="display1">
+                      <Typography
+                        className={classes.header}
+                        variant="h4"
+                        color="textSecondary"
+                      >
                         {variantId}
                       </Typography>{' '}
                       <Typography
                         className={classes.header}
-                        variant="title"
+                        variant="h6"
                         color="textSecondary"
                       >
                         {variantInfo.rsId}
@@ -243,7 +247,7 @@ class VariantPage extends React.Component {
                       ) : null}
                     </Grid>
                     <Grid item>
-                      <Typography variant="subheading">
+                      <Typography variant="subtitle1">
                         {variantInfo.nearestGene ? (
                           <Fragment>
                             Nearest Gene:{' '}
@@ -296,7 +300,7 @@ class VariantPage extends React.Component {
                     loading={loading}
                     error={error}
                     center={
-                      <Typography variant="subheading">
+                      <Typography variant="subtitle1">
                         {loading ? '...' : '(no data)'}
                       </Typography>
                     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,9 +15,9 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@babel/runtime@7.0.0-beta.56":
-  version "7.0.0-beta.56"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.56.tgz#cda612dffd5b1719a7b8e91e3040bd6ae64de8b0"
+"@babel/runtime@7.0.0", "@babel/runtime@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
   dependencies:
     regenerator-runtime "^0.12.0"
 
@@ -27,9 +27,9 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
+"@babel/runtime@7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.2.tgz#81c89935f4647706fc54541145e6b4ecfef4b8e3"
   dependencies:
     regenerator-runtime "^0.12.0"
 
@@ -93,12 +93,12 @@
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.1.tgz#f3a81587ad8d0ef33cdad6f3b4310774fcc1053e"
 
-"@material-ui/core@^1.4.3":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-1.5.1.tgz#cb00cb934447ae688e08129f1dab55f54d29d87a"
+"@material-ui/core@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.4.0.tgz#b33c00a3c20e856ed7a4700dd398f128647beb4a"
   dependencies:
-    "@babel/runtime" "7.0.0-rc.1"
-    "@types/jss" "^9.5.3"
+    "@babel/runtime" "7.1.2"
+    "@types/jss" "^9.5.6"
     "@types/react-transition-group" "^2.0.8"
     brcast "^3.0.1"
     classnames "^2.2.5"
@@ -106,7 +106,7 @@
     debounce "^1.1.0"
     deepmerge "^2.0.1"
     dom-helpers "^3.2.1"
-    hoist-non-react-statics "^2.5.0"
+    hoist-non-react-statics "^3.0.0"
     is-plain-object "^2.0.4"
     jss "^9.3.3"
     jss-camel-case "^6.0.0"
@@ -120,17 +120,16 @@
     popper.js "^1.14.1"
     prop-types "^15.6.0"
     react-event-listener "^0.6.2"
-    react-jss "^8.1.0"
     react-transition-group "^2.2.1"
-    recompose "^0.28.0"
+    recompose "0.28.0 - 0.30.0"
     warning "^4.0.1"
 
-"@material-ui/icons@^2.0.2":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-2.0.3.tgz#d3da9d6e31b1adfbc48efe33c7cb75b32b784096"
+"@material-ui/icons@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-3.0.1.tgz#671fb3d04dcaf9351dbbd2bf82ae2ae72e3d93cd"
   dependencies:
-    "@babel/runtime" "7.0.0-rc.1"
-    recompose "^0.28.0"
+    "@babel/runtime" "7.0.0"
+    recompose "^0.29.0"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -146,9 +145,9 @@
   version "0.12.6"
   resolved "http://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz#3d619198585fcabe5f4e1adfb5cf5f3388c66c13"
 
-"@types/jss@^9.5.3":
-  version "9.5.5"
-  resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.5.5.tgz#57ed99ae768c203677cd64e0ce0df02c74075bf8"
+"@types/jss@^9.5.6":
+  version "9.5.7"
+  resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.5.7.tgz#fa57a6d0b38a3abef8a425e3eb6a53495cb9d5a0"
   dependencies:
     csstype "^2.0.0"
     indefinite-observable "^1.0.1"
@@ -3912,6 +3911,12 @@ hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
+hoist-non-react-statics@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz#42414ccdfff019cd2168168be998c7b3bd5245c0"
+  dependencies:
+    react-is "^16.3.2"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -4343,10 +4348,6 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-
-is-function@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -4966,31 +4967,15 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jss-camel-case@^6.0.0, jss-camel-case@^6.1.0:
+jss-camel-case@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jss-camel-case/-/jss-camel-case-6.1.0.tgz#ccb1ff8d6c701c02a1fed6fb6fb6b7896e11ce44"
   dependencies:
     hyphenate-style-name "^1.0.2"
 
-jss-compose@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/jss-compose/-/jss-compose-5.0.0.tgz#ce01b2e4521d65c37ea42cf49116e5f7ab596484"
-  dependencies:
-    warning "^3.0.0"
-
 jss-default-unit@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-8.0.2.tgz#cc1e889bae4c0b9419327b314ab1c8e2826890e6"
-
-jss-expand@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/jss-expand/-/jss-expand-5.3.0.tgz#02be076efe650125c842f5bb6fb68786fe441ed6"
-
-jss-extend@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/jss-extend/-/jss-extend-6.2.0.tgz#4af09d0b72fb98ee229970f8ca852fec1ca2a8dc"
-  dependencies:
-    warning "^3.0.0"
 
 jss-global@^3.0.0:
   version "3.0.0"
@@ -5002,30 +4987,9 @@ jss-nested@^6.0.1:
   dependencies:
     warning "^3.0.0"
 
-jss-preset-default@^4.3.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/jss-preset-default/-/jss-preset-default-4.5.0.tgz#d3a457012ccd7a551312014e394c23c4b301cadd"
-  dependencies:
-    jss-camel-case "^6.1.0"
-    jss-compose "^5.0.0"
-    jss-default-unit "^8.0.2"
-    jss-expand "^5.3.0"
-    jss-extend "^6.2.0"
-    jss-global "^3.0.0"
-    jss-nested "^6.0.1"
-    jss-props-sort "^6.0.0"
-    jss-template "^1.0.1"
-    jss-vendor-prefixer "^7.0.0"
-
 jss-props-sort@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/jss-props-sort/-/jss-props-sort-6.0.0.tgz#9105101a3b5071fab61e2d85ea74cc22e9b16323"
-
-jss-template@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jss-template/-/jss-template-1.0.1.tgz#09aed9d86cc547b07f53ef355d7e1777f7da430a"
-  dependencies:
-    warning "^3.0.0"
 
 jss-vendor-prefixer@^7.0.0:
   version "7.0.0"
@@ -5033,7 +4997,7 @@ jss-vendor-prefixer@^7.0.0:
   dependencies:
     css-vendor "^0.3.8"
 
-jss@^9.3.3, jss@^9.7.0:
+jss@^9.3.3:
   version "9.8.7"
   resolved "https://registry.yarnpkg.com/jss/-/jss-9.8.7.tgz#ed9763fc0f2f0260fc8260dac657af61e622ce05"
   dependencies:
@@ -6862,19 +6826,13 @@ react-input-autosize@^2.2.1:
   dependencies:
     prop-types "^15.5.8"
 
+react-is@^16.3.2:
+  version "16.6.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.1.tgz#f77b1c3d901be300abe8d58645b7a59e794e5982"
+
 react-is@^16.4.2, react-is@^16.5.0:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.0.tgz#2ec7c192709698591efe13722fab3ef56144ba55"
-
-react-jss@^8.1.0:
-  version "8.6.1"
-  resolved "https://registry.yarnpkg.com/react-jss/-/react-jss-8.6.1.tgz#a06e2e1d2c4d91b4d11befda865e6c07fbd75252"
-  dependencies:
-    hoist-non-react-statics "^2.5.0"
-    jss "^9.7.0"
-    jss-preset-default "^4.3.0"
-    prop-types "^15.6.0"
-    theming "^1.3.0"
 
 react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -7079,11 +7037,22 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-recompose@^0.28.0:
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.28.2.tgz#19e679227bdf979e0d31b73ffe7ae38c9194f4a7"
+"recompose@0.28.0 - 0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.30.0.tgz#82773641b3927e8c7d24a0d87d65aeeba18aabd0"
   dependencies:
-    "@babel/runtime" "7.0.0-beta.56"
+    "@babel/runtime" "^7.0.0"
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    react-lifecycles-compat "^3.0.2"
+    symbol-observable "^1.0.4"
+
+recompose@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.29.0.tgz#f1a4e20d5f24d6ef1440f83924e821de0b1bccef"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
     change-emitter "^0.1.2"
     fbjs "^0.8.1"
     hoist-non-react-statics "^2.3.1"
@@ -8061,15 +8030,6 @@ test-exclude@^4.2.1:
 text-table@0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
-
-theming@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/theming/-/theming-1.3.0.tgz#286d5bae80be890d0adc645e5ca0498723725bdc"
-  dependencies:
-    brcast "^3.0.1"
-    is-function "^1.0.1"
-    is-plain-object "^2.0.1"
-    prop-types "^15.5.8"
 
 throat@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
In the last 3 months, the version for material ui went from 1.4 to 3.4. This PR updates the version of material ui and some other things:

- Update @material-ui/core and @material-ui/icons to the latest version
- Replace the deprecated values for the `variant` prop of the `Typography` component according to this https://material-ui.com/style/typography/#migration-to-typography-v2
- Updated the .gitignore file