### PR TITLE
Support changes for v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ yarn-error.log*
 *.swp
 
 mock-data
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ yarn-error.log*
 
 # for vim users
 *.swp
+
+mock-data

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # for vim users
-mock-data
 *.swp
 
 mock-data

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "graphql": "^0.13.2",
     "lodash": "^4.17.10",
     "ot-charts": "^0.0.40",
-    "ot-ui": "^0.0.72",
+    "ot-ui": "^0.0.73",
     "polished": "^2.1.1",
     "query-string": "5",
     "react": "^16.4.2",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   "devDependencies": {
     "babel-plugin-import": "^1.8.0",
     "codecov": "^3.0.4",
-    "enzyme": "^3.4.1",
-    "enzyme-adapter-react-16": "^1.2.0",
+    "enzyme": "^3.9.0",
+    "enzyme-adapter-react-16": "^1.12.1",
     "eslint-plugin-prettier": "^2.6.2",
     "husky": "^1.0.0-rc.13",
     "lint-staged": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "graphql": "^0.13.2",
     "lodash": "^4.17.10",
     "ot-charts": "^0.0.40",
-    "ot-ui": "^0.0.69",
+    "ot-ui": "^0.0.72",
     "polished": "^2.1.1",
     "query-string": "5",
     "react": "^16.4.2",

--- a/src/components/AssociatedGenes.js
+++ b/src/components/AssociatedGenes.js
@@ -10,6 +10,7 @@ import {
   LabelHML,
   Tooltip,
   significantFigures,
+  commaSeparate,
 } from 'ot-ui';
 
 import { pvalThreshold } from '../constants';
@@ -29,7 +30,7 @@ const createDistanceCellRenderer = schema => {
     if (distanceData !== undefined) {
       const { distance, quantile } = distanceData.tissues[0];
       const circleRadius = radiusScale(quantile);
-      return <React.Fragment>{Math.round(distance / 1000)}</React.Fragment>;
+      return <React.Fragment>{commaSeparate(distance)}</React.Fragment>;
     }
   };
 };
@@ -176,7 +177,7 @@ const getTissueColumns = (schema, genesForVariant) => {
             verticalHeader: true,
             renderCell: rowData =>
               rowData[tissue.id]
-                ? Math.round(rowData[tissue.id].distance / 1000)
+                ? commaSeparate(rowData[tissue.id].distance)
                 : null,
             comparator: generateComparator(
               d => (d[tissue.id] ? d[tissue.id].distance : null)

--- a/src/components/AssociatedGenes.js
+++ b/src/components/AssociatedGenes.js
@@ -28,8 +28,7 @@ const createDistanceCellRenderer = schema => {
   return rowData => {
     const distanceData = rowData[schema.sourceId];
     if (distanceData !== undefined) {
-      const { distance, quantile } = distanceData.tissues[0];
-      const circleRadius = radiusScale(quantile);
+      const { distance } = distanceData.tissues[0];
       return <React.Fragment>{commaSeparate(distance)}</React.Fragment>;
     }
   };
@@ -45,9 +44,6 @@ const createQtlCellRenderer = schema => {
 };
 
 const tissueComparator = (a, b) =>
-  a.label > b.label ? 1 : a.label === b.label ? 0 : -1;
-
-const distanceComparator = (a, b) =>
   a.label > b.label ? 1 : a.label === b.label ? 0 : -1;
 
 const createIntervalCellRenderer = schema => {

--- a/src/components/AssociatedIndexVariantsTable.js
+++ b/src/components/AssociatedIndexVariantsTable.js
@@ -4,6 +4,7 @@ import { OtTable, commaSeparate, significantFigures } from 'ot-ui';
 
 import { pvalThreshold } from '../constants';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
+import PmidOrBiobankLink from './PmidOrBiobankLink';
 
 const tableColumns = variantId => [
   {
@@ -74,13 +75,7 @@ const tableColumns = variantId => [
     id: 'pmid',
     label: 'PMID',
     renderCell: rowData => (
-      <a
-        href={`http://europepmc.org/abstract/med/${rowData.pmid}`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {rowData.pmid}
-      </a>
+      <PmidOrBiobankLink studyId={rowData.studyId} pmid={rowData.pmid} />
     ),
   },
   {

--- a/src/components/AssociatedIndexVariantsTable.js
+++ b/src/components/AssociatedIndexVariantsTable.js
@@ -41,6 +41,36 @@ const tableColumns = variantId => [
         : significantFigures(rowData.pval),
   },
   {
+    id: 'beta',
+    label: 'Beta',
+    tooltip: 'Beta with respect to the ALT allele',
+    renderCell: rowData =>
+      rowData.beta ? significantFigures(rowData.beta) : null,
+  },
+  {
+    id: 'oddsRatio',
+    label: 'Odds Ratio',
+    tooltip: 'Odds ratio with respect to the ALT allele',
+    renderCell: rowData =>
+      rowData.oddsRatio ? significantFigures(rowData.oddsRatio) : null,
+  },
+  {
+    id: 'ci',
+    label: '95% Confidence Interval',
+    tooltip:
+      '95% confidence interval for the effect estimate. CIs are calculated approximately using the reported p-value.',
+    renderCell: rowData =>
+      rowData.beta
+        ? `(${significantFigures(rowData.betaCILower)}, ${significantFigures(
+            rowData.betaCIUpper
+          )})`
+        : rowData.oddsRatio
+          ? `(${significantFigures(
+              rowData.oddsRatioCILower
+            )}, ${significantFigures(rowData.oddsRatioCIUpper)})`
+          : null,
+  },
+  {
     id: 'pmid',
     label: 'PMID',
     renderCell: rowData => (

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -24,15 +24,6 @@ const tableColumns = ({
   authorFilterHandler,
 }) => [
   {
-    id: 'indexVariant.id',
-    label: 'Lead Variant',
-    renderCell: rowData => (
-      <Link to={`/variant/${rowData.indexVariant.id}`}>
-        {rowData.indexVariant.rsId}
-      </Link>
-    ),
-  },
-  {
     id: 'study.studyId',
     label: 'Study ID',
     renderCell: rowData => (
@@ -101,6 +92,15 @@ const tableColumns = ({
     label: 'N Cases',
     renderCell: rowData =>
       rowData.study.nCases ? commaSeparate(rowData.study.nCases) : '',
+  },
+  {
+    id: 'indexVariant.id',
+    label: 'Lead Variant',
+    renderCell: rowData => (
+      <Link to={`/variant/${rowData.indexVariant.id}`}>
+        {rowData.indexVariant.rsId}
+      </Link>
+    ),
   },
   {
     id: 'pval',

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -199,7 +199,7 @@ const tableColumns = ({
         chromosome={chromosome}
         position={position}
         selectedGenes={[geneId]}
-        selectedStudies={[rowData.studyId]}
+        selectedStudies={[rowData.study.studyId]}
       >
         Locus
       </LocusLink>

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -11,6 +11,7 @@ import { pvalThreshold } from '../constants';
 import LocusLink from './LocusLink';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
 import PmidOrBiobankLink from './PmidOrBiobankLink';
+import generateComparator from '../utils/generateComparator';
 
 const tableColumns = ({
   geneId,
@@ -26,6 +27,7 @@ const tableColumns = ({
   {
     id: 'study.studyId',
     label: 'Study ID',
+    comparator: generateComparator(d => d.study.studyId),
     renderCell: rowData => (
       <Link to={`/study/${rowData.study.studyId}`}>
         {rowData.study.studyId}
@@ -35,6 +37,7 @@ const tableColumns = ({
   {
     id: 'study.traitReported',
     label: 'Trait',
+    comparator: generateComparator(d => d.study.traitReported),
     renderCell: rowData => rowData.study.traitReported,
     renderFilter: () => (
       <Autocomplete
@@ -49,6 +52,7 @@ const tableColumns = ({
   {
     id: 'study.pmid',
     label: 'PMID',
+    comparator: generateComparator(d => d.study.pmid),
     renderCell: rowData => (
       <PmidOrBiobankLink
         studyId={rowData.study.studyId}
@@ -59,6 +63,7 @@ const tableColumns = ({
   {
     id: 'study.pubAuthor',
     label: 'Author (Year)',
+    comparator: generateComparator(d => d.study.pubAuthor),
     renderFilter: () => (
       <Autocomplete
         options={authorFilterOptions}
@@ -76,12 +81,14 @@ const tableColumns = ({
   {
     id: 'study.nInitial',
     label: 'N Initial',
+    comparator: generateComparator(d => d.study.nInitial),
     renderCell: rowData =>
       rowData.study.nInitial ? commaSeparate(rowData.study.nInitial) : '',
   },
   {
     id: 'study.nReplication',
     label: 'N Replication',
+    comparator: generateComparator(d => d.study.nReplication),
     renderCell: rowData =>
       rowData.study.nReplication
         ? commaSeparate(rowData.study.nReplication)
@@ -90,12 +97,14 @@ const tableColumns = ({
   {
     id: 'study.nCases',
     label: 'N Cases',
+    comparator: generateComparator(d => d.study.nCases),
     renderCell: rowData =>
       rowData.study.nCases ? commaSeparate(rowData.study.nCases) : '',
   },
   {
     id: 'indexVariant.id',
     label: 'Lead Variant',
+    comparator: generateComparator(d => d.indexVariant.rsId),
     renderCell: rowData => (
       <Link to={`/variant/${rowData.indexVariant.id}`}>
         {rowData.indexVariant.rsId}
@@ -187,7 +196,7 @@ const AssociatedStudiesTable = ({
       authorFilterHandler,
     })}
     data={data}
-    sortBy="nInitial"
+    sortBy="study.nInitial"
     order="desc"
     downloadFileStem={filenameStem}
     reportTableDownloadEvent={format => {

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -4,6 +4,7 @@ import { OtTable, commaSeparate, Autocomplete } from 'ot-ui';
 
 import LocusLink from './LocusLink';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
+import PmidOrBiobankLink from './PmidOrBiobankLink';
 
 const tableColumns = ({
   geneId,
@@ -40,13 +41,7 @@ const tableColumns = ({
     id: 'pmid',
     label: 'PMID',
     renderCell: rowData => (
-      <a
-        href={`http://europepmc.org/abstract/med/${rowData.pmid}`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {rowData.pmid}
-      </a>
+      <PmidOrBiobankLink studyId={rowData.studyId} pmid={rowData.pmid} />
     ),
   },
   {

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -131,15 +131,6 @@ const tableColumns = ({
       rowData.study.nInitial ? commaSeparate(rowData.study.nInitial) : '',
   },
   {
-    id: 'study.nReplication',
-    label: 'N Replication',
-    comparator: generateComparator(d => d.study.nReplication),
-    renderCell: rowData =>
-      rowData.study.nReplication
-        ? commaSeparate(rowData.study.nReplication)
-        : '',
-  },
-  {
     id: 'study.nCases',
     label: 'N Cases',
     comparator: generateComparator(d => d.study.nCases),

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import {
-  OtTable,
+  DataDownloader,
+  OtTableRF,
   commaSeparate,
   significantFigures,
   Autocomplete,
@@ -12,6 +13,50 @@ import LocusLink from './LocusLink';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
 import PmidOrBiobankLink from './PmidOrBiobankLink';
 import generateComparator from '../utils/generateComparator';
+
+const getDownloadColumns = () => {
+  return [
+    { id: 'studyId', label: 'Study ID' },
+    { id: 'studyTrait', label: 'Reported Trait' },
+    { id: 'studyPmid', label: 'PMID' },
+    { id: 'studyAuthor', label: 'Author' },
+    { id: 'studyDate', label: 'Date' },
+    { id: 'nInitial', label: 'Study N Initial' },
+    { id: 'nReplication', label: 'Study N Replication' },
+    { id: 'nCases', label: 'Study N Cases' },
+    { id: 'indexVariantId', label: 'Index Variant ID' },
+    { id: 'indexVariantRsId', label: 'Index Variant RSID' },
+    { id: 'pval', label: 'P-Value' },
+    { id: 'beta', label: 'Beta' },
+    { id: 'betaCILower', label: 'Beta CI Lower' },
+    { id: 'betaCIUpper', label: 'Beta CI Upper' },
+    { id: 'oddsRatio', label: 'Odds Ratio' },
+    { id: 'oddsRatioCILower', label: 'Odds Ratio CI Lower' },
+    { id: 'oddsRatioCIUpper', label: 'Odds Ratio CI Upper' },
+  ];
+};
+
+const getDownloadRows = rows => {
+  return rows.map(row => ({
+    studyId: row.study.studyId,
+    studyTrait: row.study.traitReported,
+    studyPmid: row.study.pmid,
+    studyAuthor: row.study.pubAuthor,
+    studyDate: row.study.pubDate,
+    nInitial: row.study.nInitial,
+    nReplication: row.study.nReplication,
+    nCases: row.study.nCases,
+    indexVariantId: row.indexVariant.id,
+    indexVariantRsId: row.indexVariant.rsId,
+    pval: row.pval,
+    beta: row.beta,
+    betaCILower: row.betaCILower,
+    betaCIUpper: row.betaCIUpper,
+    oddsRatio: row.oddsRatio,
+    oddsRatioCILower: row.oddsRatioCILower,
+    oddsRatioCIUpper: row.oddsRatioCIUpper,
+  }));
+};
 
 const tableColumns = ({
   geneId,
@@ -180,40 +225,46 @@ const AssociatedStudiesTable = ({
   authorFilterOptions,
   authorFilterHandler,
 }) => (
-  <OtTable
-    loading={loading}
-    error={error}
-    filters
-    columns={tableColumns({
-      geneId,
-      chromosome,
-      position,
-      traitFilterValue,
-      traitFilterOptions,
-      traitFilterHandler,
-      authorFilterValue,
-      authorFilterOptions,
-      authorFilterHandler,
-    })}
-    data={data}
-    sortBy="study.nInitial"
-    order="desc"
-    downloadFileStem={filenameStem}
-    reportTableDownloadEvent={format => {
-      reportAnalyticsEvent({
-        category: 'table',
-        action: 'download',
-        label: `gene:associated-studies:${format}`,
-      });
-    }}
-    reportTableSortEvent={(sortBy, order) => {
-      reportAnalyticsEvent({
-        category: 'table',
-        action: 'sort-column',
-        label: `gene:associated-studies:${sortBy}(${order})`,
-      });
-    }}
-  />
+  <React.Fragment>
+    <DataDownloader
+      tableHeaders={getDownloadColumns()}
+      rows={getDownloadRows(data)}
+      fileStem={filenameStem}
+    />
+    <OtTableRF
+      loading={loading}
+      error={error}
+      filters
+      columns={tableColumns({
+        geneId,
+        chromosome,
+        position,
+        traitFilterValue,
+        traitFilterOptions,
+        traitFilterHandler,
+        authorFilterValue,
+        authorFilterOptions,
+        authorFilterHandler,
+      })}
+      data={data}
+      sortBy="study.nInitial"
+      order="desc"
+      reportTableDownloadEvent={format => {
+        reportAnalyticsEvent({
+          category: 'table',
+          action: 'download',
+          label: `gene:associated-studies:${format}`,
+        });
+      }}
+      reportTableSortEvent={(sortBy, order) => {
+        reportAnalyticsEvent({
+          category: 'table',
+          action: 'sort-column',
+          label: `gene:associated-studies:${sortBy}(${order})`,
+        });
+      }}
+    />
+  </React.Fragment>
 );
 
 export default AssociatedStudiesTable;

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -140,12 +140,18 @@ const tableColumns = ({
   {
     id: 'indexVariant.id',
     label: 'Lead Variant',
-    comparator: generateComparator(d => d.indexVariant.rsId),
+    comparator: generateComparator(d => d.indexVariant.id),
     renderCell: rowData => (
       <Link to={`/variant/${rowData.indexVariant.id}`}>
-        {rowData.indexVariant.rsId}
+        {rowData.indexVariant.id}
       </Link>
     ),
+  },
+  {
+    id: 'indexVariant.rsId',
+    label: 'Lead Variant rsID',
+    comparator: generateComparator(d => d.indexVariant.rsId),
+    renderCell: rowData => rowData.indexVariant.rsId,
   },
   {
     id: 'pval',

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -247,8 +247,8 @@ const AssociatedStudiesTable = ({
         authorFilterHandler,
       })}
       data={data}
-      sortBy="study.nInitial"
-      order="desc"
+      sortBy="pval"
+      order="asc"
       reportTableDownloadEvent={format => {
         reportAnalyticsEvent({
           category: 'table',

--- a/src/components/AssociatedTagVariantsTable.js
+++ b/src/components/AssociatedTagVariantsTable.js
@@ -4,6 +4,7 @@ import { OtTable, commaSeparate, significantFigures } from 'ot-ui';
 
 import { pvalThreshold } from '../constants';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
+import PmidOrBiobankLink from './PmidOrBiobankLink';
 
 const tableColumns = variantId => [
   {
@@ -44,13 +45,7 @@ const tableColumns = variantId => [
     id: 'pmid',
     label: 'PMID',
     renderCell: rowData => (
-      <a
-        href={`http://europepmc.org/abstract/med/${rowData.pmid}`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {rowData.pmid}
-      </a>
+      <PmidOrBiobankLink studyId={rowData.studyId} pmid={rowData.pmid} />
     ),
   },
   {

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -1,10 +1,18 @@
 import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
+import Card from '@material-ui/core/Card';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
+import Tooltip from '@material-ui/core/Tooltip';
+import Badge from '@material-ui/core/Badge';
+import HelpIcon from '@material-ui/icons/Help';
+
+import { Typography, PlotContainer, PlotContainerSection } from 'ot-ui';
+import { CardContent } from '@material-ui/core';
 
 const populations = [
   { code: 'AFR', description: 'African/African-American' },
@@ -22,27 +30,59 @@ const populations = [
   { code: 'OTH', description: 'Other (population not assigned)' },
 ];
 
-const GnomADTable = ({ data }) => (
-  <Paper>
-    <Table>
-      <TableHead>
-        <TableRow>
-          <TableCell>Code</TableCell>
-          <TableCell>Population</TableCell>
-          <TableCell>Minor Allele Frequency</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
+const styles = () => ({
+  tooltipIcon: {
+    fontSize: '1.2rem',
+    paddingLeft: `0.6rem`,
+  },
+  valueWithBadgedLabel: {
+    verticalAlign: 'middle',
+    paddingLeft: '0.6rem',
+    paddingRight: '1rem',
+  },
+  value: {
+    paddingLeft: '0.6rem',
+    paddingRight: '1rem',
+  },
+  cardContent: {
+    padding: '8px !important',
+  },
+});
+
+const GnomADTable = ({ classes, data }) => (
+  <Card>
+    <CardContent className={classes.cardContent}>
+      <Typography variant="subtitle1">
+        CADD (Combined Annotation Dependent Depletion)
+      </Typography>
+      <Typography variant="subtitle2">
+        <strong>raw: </strong>
+        <span className={classes.value}>{data.caddRaw}</span>
+        <strong>scaled: </strong>
+        <span className={classes.value}>{data.caddPhred}</span>
+      </Typography>
+      <br />
+      <Typography variant="subtitle1">Population allele frequencies</Typography>
+      <Typography variant="subtitle2">
         {populations.map(p => (
-          <TableRow key={p.code}>
-            <TableCell>{p.code}</TableCell>
-            <TableCell>{p.description}</TableCell>
-            <TableCell>{data[`gnomad${p.code}`].toPrecision(3)}</TableCell>
-          </TableRow>
+          <React.Fragment key={p.code}>
+            <Badge
+              badgeContent={
+                <Tooltip title={p.description} placement="top">
+                  <HelpIcon className={classes.tooltipIcon} />
+                </Tooltip>
+              }
+            >
+              <strong>{p.code}: </strong>
+            </Badge>
+            <span className={classes.valueWithBadgedLabel}>
+              {data[`gnomad${p.code}`].toPrecision(3)}
+            </span>
+          </React.Fragment>
         ))}
-      </TableBody>
-    </Table>
-  </Paper>
+      </Typography>
+    </CardContent>
+  </Card>
 );
 
-export default GnomADTable;
+export default withStyles(styles)(GnomADTable);

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -68,7 +68,7 @@ const styles = () => ({
 
 const GnomADTable = ({ classes, data }) => (
   <Grid container justify="space-between">
-    <Grid item xs={12} md={6}>
+    <Grid item xs={12} sm={6} md={8}>
       <Typography variant="subtitle1">Neighbourhood</Typography>
       <Typography variant="subtitle2">
         <strong>
@@ -118,7 +118,7 @@ const GnomADTable = ({ classes, data }) => (
         <span className={classes.value}>{data.caddPhred.toPrecision(3)}</span>
       </Typography>
     </Grid>
-    <Grid item xs={12} md={6}>
+    <Grid item xs={12} sm={6} md={4}>
       <Typography variant="subtitle1">
         Population allele frequencies (
         <a href="https://gnomad.broadinstitute.org/" target="_blank">
@@ -135,7 +135,7 @@ const GnomADTable = ({ classes, data }) => (
       </Typography>
       <Grid container>
         {populations.map(p => (
-          <React.Fragment>
+          <React.Fragment key={p.code}>
             <Grid item xs={6}>
               <Typography variant="subtitle2">{p.description}</Typography>
             </Grid>

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Card from '@material-ui/core/Card';
 import Table from '@material-ui/core/Table';
@@ -66,8 +67,8 @@ const styles = () => ({
 });
 
 const GnomADTable = ({ classes, data }) => (
-  <Card>
-    <CardContent className={classes.cardContent}>
+  <Grid container justify="space-between">
+    <Grid item xs={12} md={6}>
       <Typography variant="subtitle1">Neighbourhood</Typography>
       <Typography variant="subtitle2">
         <strong>
@@ -116,7 +117,8 @@ const GnomADTable = ({ classes, data }) => (
         <strong>scaled: </strong>
         <span className={classes.value}>{data.caddPhred.toPrecision(3)}</span>
       </Typography>
-      <br />
+    </Grid>
+    <Grid item xs={12} md={6}>
       <Typography variant="subtitle1">
         Population allele frequencies (
         <a href="https://gnomad.broadinstitute.org/" target="_blank">
@@ -131,7 +133,22 @@ const GnomADTable = ({ classes, data }) => (
         </a>
         )
       </Typography>
-      <Typography variant="subtitle2">
+      <Grid container>
+        {populations.map(p => (
+          <React.Fragment>
+            <Grid item xs={6}>
+              <Typography variant="subtitle2">{p.description}</Typography>
+            </Grid>
+            <Grid item xs={6}>
+              <Typography variant="subtitle2" align="right">
+                {data[`gnomad${p.code}`].toPrecision(3)}
+              </Typography>
+            </Grid>
+          </React.Fragment>
+        ))}
+      </Grid>
+
+      {/* <Typography variant="subtitle2">
         {populations.map(p => (
           <React.Fragment key={p.code}>
             <Badge
@@ -148,9 +165,9 @@ const GnomADTable = ({ classes, data }) => (
             </span>
           </React.Fragment>
         ))}
-      </Typography>
-    </CardContent>
-  </Card>
+      </Typography> */}
+    </Grid>
+  </Grid>
 );
 
 export default withStyles(styles)(GnomADTable);

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import Paper from '@material-ui/core/Paper';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+
+const populations = [
+  { code: 'AFR', description: 'African/African-American' },
+  { code: 'AMR', description: 'Latino/Admixed American' },
+  { code: 'ASJ', description: 'Ashkenazi Jewish' },
+  { code: 'EAS', description: 'East Asian' },
+  { code: 'FIN', description: 'Finnish' },
+  { code: 'NFE', description: 'Non-Finnish European' },
+  { code: 'NFEEST', description: 'Non-Finnish Eurpoean Estonian' },
+  {
+    code: 'NFENWE',
+    description: 'Non-Finnish Eurpoean North-Western European',
+  },
+  { code: 'NFESEU', description: 'Non-Finnish Eurpoean Southern European' },
+  { code: 'OTH', description: 'Other (population not assigned)' },
+];
+
+const GnomADTable = ({ data }) => (
+  <Paper>
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>Code</TableCell>
+          <TableCell>Population</TableCell>
+          <TableCell>Minor Allele Frequency</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {populations.map(p => (
+          <TableRow key={p.code}>
+            <TableCell>{p.code}</TableCell>
+            <TableCell>{p.description}</TableCell>
+            <TableCell>{data[`gnomad${p.code}`].toPrecision(3)}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  </Paper>
+);
+
+export default GnomADTable;

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
@@ -13,7 +14,12 @@ import Badge from '@material-ui/core/Badge';
 import Icon from '@material-ui/core/Icon';
 import HelpIcon from '@material-ui/icons/Help';
 
-import { Typography, PlotContainer, PlotContainerSection } from 'ot-ui';
+import {
+  Typography,
+  PlotContainer,
+  PlotContainerSection,
+  commaSeparate,
+} from 'ot-ui';
 import { CardContent } from '@material-ui/core';
 
 const populations = [
@@ -62,6 +68,34 @@ const styles = () => ({
 const GnomADTable = ({ classes, data }) => (
   <Card>
     <CardContent className={classes.cardContent}>
+      <Typography variant="subtitle1">Neighbourhood</Typography>
+      <Typography variant="subtitle2">
+        <strong>
+          Nearest gene ({commaSeparate(data.nearestGeneDistance)} bp to
+          canonical TSS):
+        </strong>{' '}
+        <Link to={`/gene/${data.nearestGene.id}`}>
+          {data.nearestGene.symbol}
+        </Link>
+      </Typography>
+      <Typography variant="subtitle2">
+        <strong>
+          Nearest coding gene ({commaSeparate(data.nearestCodingGeneDistance)}{' '}
+          bp to canonical TSS):
+        </strong>{' '}
+        <Link to={`/gene/${data.nearestCodingGene.id}`}>
+          {data.nearestCodingGene.symbol}
+        </Link>
+      </Typography>
+      <br />
+
+      <Typography variant="subtitle1">VEP</Typography>
+      <Typography variant="subtitle2">
+        <strong>Most severe consequence:</strong>{' '}
+        {data.mostSevereConsequence.replace(/_/g, ' ')}
+      </Typography>
+      <br />
+
       <Typography variant="subtitle1">
         Combined Annotation Dependent Depletion (
         <a href="https://cadd.gs.washington.edu/" target="_blank">

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -136,10 +136,10 @@ const GnomADTable = ({ classes, data }) => (
       <Grid container>
         {populations.map(p => (
           <React.Fragment key={p.code}>
-            <Grid item xs={6}>
+            <Grid item xs={9}>
               <Typography variant="subtitle2">{p.description}</Typography>
             </Grid>
-            <Grid item xs={6}>
+            <Grid item xs={3}>
               <Typography variant="subtitle2" align="right">
                 {data[`gnomad${p.code}`].toPrecision(3)}
               </Typography>

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -78,9 +78,9 @@ const GnomADTable = ({ classes, data }) => (
       </Typography>
       <Typography variant="subtitle2">
         <strong>raw: </strong>
-        <span className={classes.value}>{data.caddRaw}</span>
+        <span className={classes.value}>{data.caddRaw.toPrecision(3)}</span>
         <strong>scaled: </strong>
-        <span className={classes.value}>{data.caddPhred}</span>
+        <span className={classes.value}>{data.caddPhred.toPrecision(3)}</span>
       </Typography>
       <br />
       <Typography variant="subtitle1">

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -61,6 +61,7 @@ const GnomADTable = ({ classes, data, variantId }) => (
             data.rsId
           }`}
           target="_blank"
+          rel="noopener noreferrer"
         >
           {data.rsId}
           <Icon
@@ -81,6 +82,7 @@ const GnomADTable = ({ classes, data, variantId }) => (
               '-'
             )}`}
             target="_blank"
+            rel="noopener noreferrer"
           >
             {variantId.replace(/_/g, '-')}
             <Icon
@@ -121,6 +123,7 @@ const GnomADTable = ({ classes, data, variantId }) => (
         <a
           href="https://www.ensembl.org/info/docs/tools/vep/index.html"
           target="_blank"
+          rel="noopener noreferrer"
         >
           VEP
           <Icon
@@ -141,7 +144,11 @@ const GnomADTable = ({ classes, data, variantId }) => (
 
       <Typography variant="subtitle1">
         Combined Annotation Dependent Depletion (
-        <a href="https://cadd.gs.washington.edu/" target="_blank">
+        <a
+          href="https://cadd.gs.washington.edu/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           CADD
           <Icon
             className={classNames(
@@ -163,7 +170,11 @@ const GnomADTable = ({ classes, data, variantId }) => (
     <Grid item xs={12} sm={6} md={4}>
       <Typography variant="subtitle1">
         Population allele frequencies (
-        <a href="https://gnomad.broadinstitute.org/" target="_blank">
+        <a
+          href="https://gnomad.broadinstitute.org/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           gnomAD
           <Icon
             className={classNames(

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -53,7 +53,7 @@ const styles = () => ({
 const GnomADTable = ({ classes, data, variantId }) => (
   <Grid container justify="space-between">
     <Grid item xs={12} sm={6} md={8}>
-      <Typography variant="subtitle1">External References</Typography>
+      <Typography variant="subtitle1">External references</Typography>
       <Typography variant="subtitle2">
         <strong>Ensembl:</strong>{' '}
         <a

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -14,12 +14,12 @@ const populations = [
   { code: 'EAS', description: 'East Asian' },
   { code: 'FIN', description: 'Finnish' },
   { code: 'NFE', description: 'Non-Finnish European' },
-  { code: 'NFEEST', description: 'Non-Finnish Eurpoean Estonian' },
+  { code: 'NFEEST', description: 'Non-Finnish European Estonian' },
   {
     code: 'NFENWE',
-    description: 'Non-Finnish Eurpoean North-Western European',
+    description: 'Non-Finnish European North-Western European',
   },
-  { code: 'NFESEU', description: 'Non-Finnish Eurpoean Southern European' },
+  { code: 'NFESEU', description: 'Non-Finnish European Southern European' },
   { code: 'OTH', description: 'Other (population not assigned)' },
 ];
 

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -3,25 +3,9 @@ import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
-import Paper from '@material-ui/core/Paper';
-import Card from '@material-ui/core/Card';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import Tooltip from '@material-ui/core/Tooltip';
-import Badge from '@material-ui/core/Badge';
 import Icon from '@material-ui/core/Icon';
-import HelpIcon from '@material-ui/icons/Help';
 
-import {
-  Typography,
-  PlotContainer,
-  PlotContainerSection,
-  commaSeparate,
-} from 'ot-ui';
-import { CardContent } from '@material-ui/core';
+import { Typography, commaSeparate } from 'ot-ui';
 
 const populations = [
   { code: 'AFR', description: 'African/African-American' },
@@ -66,9 +50,51 @@ const styles = () => ({
   },
 });
 
-const GnomADTable = ({ classes, data }) => (
+const GnomADTable = ({ classes, data, variantId }) => (
   <Grid container justify="space-between">
     <Grid item xs={12} sm={6} md={8}>
+      <Typography variant="subtitle1">External References</Typography>
+      <Typography variant="subtitle2">
+        <strong>Ensembl:</strong>{' '}
+        <a
+          href={`http://grch37.ensembl.org/Homo_sapiens/Variation/Explore?v=${
+            data.rsId
+          }`}
+          target="_blank"
+        >
+          {data.rsId}
+          <Icon
+            className={classNames(
+              'fa',
+              'fa-external-link-alt',
+              classes.externalLinkIcon
+            )}
+          />
+        </a>
+      </Typography>
+      <Typography variant="subtitle2">
+        <strong>gnomAD:</strong>{' '}
+        {variantId ? (
+          <a
+            href={`http://gnomad.broadinstitute.org/variant/${variantId.replace(
+              /_/g,
+              '-'
+            )}`}
+            target="_blank"
+          >
+            {variantId.replace(/_/g, '-')}
+            <Icon
+              className={classNames(
+                'fa',
+                'fa-external-link-alt',
+                classes.externalLinkIcon
+              )}
+            />
+          </a>
+        ) : null}
+      </Typography>
+      <br />
+
       <Typography variant="subtitle1">Neighbourhood</Typography>
       <Typography variant="subtitle2">
         <strong>
@@ -90,7 +116,23 @@ const GnomADTable = ({ classes, data }) => (
       </Typography>
       <br />
 
-      <Typography variant="subtitle1">VEP</Typography>
+      <Typography variant="subtitle1">
+        Variant Effect Predictor (
+        <a
+          href="https://www.ensembl.org/info/docs/tools/vep/index.html"
+          target="_blank"
+        >
+          VEP
+          <Icon
+            className={classNames(
+              'fa',
+              'fa-external-link-alt',
+              classes.externalLinkIcon
+            )}
+          />
+        </a>
+        )
+      </Typography>
       <Typography variant="subtitle2">
         <strong>Most severe consequence:</strong>{' '}
         {data.mostSevereConsequence.replace(/_/g, ' ')}
@@ -147,25 +189,6 @@ const GnomADTable = ({ classes, data }) => (
           </React.Fragment>
         ))}
       </Grid>
-
-      {/* <Typography variant="subtitle2">
-        {populations.map(p => (
-          <React.Fragment key={p.code}>
-            <Badge
-              badgeContent={
-                <Tooltip title={p.description} placement="top">
-                  <HelpIcon className={classes.tooltipIcon} />
-                </Tooltip>
-              }
-            >
-              <strong>{p.code}: </strong>
-            </Badge>
-            <span className={classes.valueWithBadgedLabel}>
-              {data[`gnomad${p.code}`].toPrecision(3)}
-            </span>
-          </React.Fragment>
-        ))}
-      </Typography> */}
     </Grid>
   </Grid>
 );

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Card from '@material-ui/core/Card';
@@ -9,6 +10,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Tooltip from '@material-ui/core/Tooltip';
 import Badge from '@material-ui/core/Badge';
+import Icon from '@material-ui/core/Icon';
 import HelpIcon from '@material-ui/icons/Help';
 
 import { Typography, PlotContainer, PlotContainerSection } from 'ot-ui';
@@ -47,13 +49,32 @@ const styles = () => ({
   cardContent: {
     padding: '8px !important',
   },
+  externalLinkIcon: {
+    fontSize: '0.7rem',
+    verticalAlign: 'middle',
+    marginLeft: '3px',
+
+    width: '1rem',
+    height: '1rem',
+  },
 });
 
 const GnomADTable = ({ classes, data }) => (
   <Card>
     <CardContent className={classes.cardContent}>
       <Typography variant="subtitle1">
-        CADD (Combined Annotation Dependent Depletion)
+        Combined Annotation Dependent Depletion (
+        <a href="https://cadd.gs.washington.edu/" target="_blank">
+          CADD
+          <Icon
+            className={classNames(
+              'fa',
+              'fa-external-link-alt',
+              classes.externalLinkIcon
+            )}
+          />
+        </a>
+        )
       </Typography>
       <Typography variant="subtitle2">
         <strong>raw: </strong>
@@ -62,7 +83,20 @@ const GnomADTable = ({ classes, data }) => (
         <span className={classes.value}>{data.caddPhred}</span>
       </Typography>
       <br />
-      <Typography variant="subtitle1">Population allele frequencies</Typography>
+      <Typography variant="subtitle1">
+        Population allele frequencies (
+        <a href="https://gnomad.broadinstitute.org/" target="_blank">
+          gnomAD
+          <Icon
+            className={classNames(
+              'fa',
+              'fa-external-link-alt',
+              classes.externalLinkIcon
+            )}
+          />
+        </a>
+        )
+      </Typography>
       <Typography variant="subtitle2">
         {populations.map(p => (
           <React.Fragment key={p.code}>

--- a/src/components/LocusLink.js
+++ b/src/components/LocusLink.js
@@ -16,9 +16,11 @@ const mb = 1000000;
 const styles = {
   button: {
     lineHeight: 1,
+    minWidth: '110px',
   },
   buttonBig: {
     fontSize: '1.1rem',
+    minWidth: '150px',
     width: '150px',
     height: '40px',
     paddingLeft: '15px',

--- a/src/components/LocusLink.js
+++ b/src/components/LocusLink.js
@@ -76,7 +76,7 @@ const LocusLink = ({
       className={classes.link}
     >
       <Button gradient className={big ? classes.buttonBig : classes.button}>
-        LocusPlot
+        Locus Plot
         <LocusIcon className={big ? classes.iconBig : classes.icon} />
       </Button>
     </Link>

--- a/src/components/LocusLink.js
+++ b/src/components/LocusLink.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import queryString from 'query-string';
+import { withStyles } from '@material-ui/core';
 
-import { Button } from 'ot-ui';
+import { Button, LocusIcon } from 'ot-ui';
 import { chromosomesWithCumulativeLengths } from 'ot-charts';
 
 const chromosomeDict = chromosomesWithCumulativeLengths.reduce((acc, d) => {
@@ -12,8 +13,36 @@ const chromosomeDict = chromosomesWithCumulativeLengths.reduce((acc, d) => {
 
 const mb = 1000000;
 
+const styles = {
+  button: {
+    lineHeight: 1,
+  },
+  buttonBig: {
+    fontSize: '1.1rem',
+    width: '150px',
+    height: '40px',
+    paddingLeft: '15px',
+  },
+  icon: {
+    fill: 'white',
+    width: '20px',
+    height: '20px',
+    marginTop: '-5px',
+    marginBottom: '-5px',
+    marginLeft: '5px',
+  },
+  iconBig: {
+    fill: 'white',
+    width: '30px',
+    height: '30px',
+  },
+  link: {
+    textDecoration: 'none',
+  },
+};
+
 const LocusLink = ({
-  children,
+  big,
   chromosome,
   position,
   selectedGenes,
@@ -44,13 +73,14 @@ const LocusLink = ({
   return (
     <Link
       to={`/locus?${queryString.stringify(params)}`}
-      style={{ textDecoration: 'none' }}
+      className={classes.link}
     >
-      <Button className={classes ? classes.button : null} gradient>
-        {children}
+      <Button gradient className={big ? classes.buttonBig : classes.button}>
+        LocusPlot
+        <LocusIcon className={big ? classes.iconBig : classes.icon} />
       </Button>
     </Link>
   );
 };
 
-export default LocusLink;
+export default withStyles(styles)(LocusLink);

--- a/src/components/LocusTable.js
+++ b/src/components/LocusTable.js
@@ -117,6 +117,36 @@ export const tableColumns = ({
         : significantFigures(rowData.pval),
   },
   {
+    id: 'beta',
+    label: 'Beta',
+    tooltip: 'Beta with respect to the ALT allele',
+    renderCell: rowData =>
+      rowData.beta ? significantFigures(rowData.beta) : null,
+  },
+  {
+    id: 'oddsRatio',
+    label: 'Odds Ratio',
+    tooltip: 'Odds ratio with respect to the ALT allele',
+    renderCell: rowData =>
+      rowData.oddsRatio ? significantFigures(rowData.oddsRatio) : null,
+  },
+  {
+    id: 'ci',
+    label: '95% Confidence Interval',
+    tooltip:
+      '95% confidence interval for the effect estimate. CIs are calculated approximately using the reported p-value.',
+    renderCell: rowData =>
+      rowData.beta
+        ? `(${significantFigures(rowData.betaCILower)}, ${significantFigures(
+            rowData.betaCIUpper
+          )})`
+        : rowData.oddsRatio
+          ? `(${significantFigures(
+              rowData.oddsRatioCILower
+            )}, ${significantFigures(rowData.oddsRatioCIUpper)})`
+          : null,
+  },
+  {
     id: 'method',
     label: 'Expansion',
     renderCell: rowData =>

--- a/src/components/ManhattanContainer.js
+++ b/src/components/ManhattanContainer.js
@@ -1,0 +1,154 @@
+import React from 'react';
+
+import { Manhattan, chromosomesWithCumulativeLengths } from 'ot-charts';
+import { SectionHeading, DownloadSVGPlot, ListTooltip } from 'ot-ui';
+
+import ManhattanTable, { tableColumns } from '../components/ManhattanTable';
+import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
+
+const maxPos =
+  chromosomesWithCumulativeLengths[chromosomesWithCumulativeLengths.length - 1]
+    .cumulativeLength;
+const SIGNIFICANCE = 5e-8;
+
+function hasAssociations(data) {
+  return (
+    data &&
+    data.manhattan &&
+    data.manhattan.associations &&
+    data.manhattan.associations.length > 0
+  );
+}
+
+function transformAssociations(data) {
+  // TODO: API should fix this
+  const zeroPvals = data.manhattan.associations.filter(d => d.pval === 0);
+  if (zeroPvals.length > 0) {
+    console.error('Found zero pvalues in Manhattan data: ', zeroPvals);
+  }
+
+  return data.manhattan.associations.filter(d => d.pval > 0).map(d => {
+    const { variant, ...rest } = d;
+    const ch = chromosomesWithCumulativeLengths.find(
+      ch => ch.name === variant.chromosome
+    );
+
+    return {
+      ...rest,
+      indexVariantId: variant.id,
+      indexVariantRsId: variant.rsId,
+      chromosome: variant.chromosome,
+      position: variant.position,
+      globalPosition: ch.cumulativeLength - ch.length + variant.position,
+    };
+  });
+}
+
+function significantLoci(data) {
+  return hasAssociations(data)
+    ? data.manhattan.associations.filter(d => d.pval < SIGNIFICANCE).length
+    : 0;
+}
+
+function loci(data) {
+  return hasAssociations(data) ? data.manhattan.associations.length : 0;
+}
+
+class ManhattanContainer extends React.Component {
+  state = {
+    associations: [],
+    start: 0,
+    end: maxPos,
+  };
+
+  manhattanPlot = React.createRef();
+
+  handleZoom = (start, end) => {
+    const { start: prevStart, end: prevEnd } = this.state;
+    if (start !== prevStart || end !== prevEnd) {
+      this.setState({ start, end });
+    }
+  };
+
+  transformData = () => {
+    const { data } = this.props;
+    const isAssociatedStudy = hasAssociations(data);
+    const associations = isAssociatedStudy ? transformAssociations(data) : [];
+    this.setState({ associations });
+  };
+
+  componentDidMount() {
+    this.transformData();
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { data } = this.props;
+    if (data !== prevProps.data) {
+      this.transformData();
+    }
+  }
+
+  render() {
+    const { data, loading, error, studyId } = this.props;
+    const { associations, start, end } = this.state;
+
+    const significantLociCount = significantLoci(data);
+    const lociCount = loci(data);
+    return (
+      <React.Fragment>
+        <SectionHeading
+          heading="Independently-associated loci"
+          subheading={
+            !loading
+              ? `Found ${significantLociCount} loci with genome-wide
+              significance (p-value < 5e-8) out of ${lociCount}`
+              : null
+          }
+          entities={[
+            {
+              type: 'study',
+              fixed: true,
+            },
+            {
+              type: 'indexVariant',
+              fixed: false,
+            },
+          ]}
+        />
+        <DownloadSVGPlot
+          svgContainer={this.manhattanPlot}
+          loading={loading}
+          error={error}
+          filenameStem={`${studyId}-independently-associated-loci`}
+          reportDownloadEvent={() =>
+            reportAnalyticsEvent({
+              category: 'visualisation',
+              action: 'download',
+              label: `study:manhattan:svg`,
+            })
+          }
+        >
+          <Manhattan
+            ref={this.manhattanPlot}
+            associations={associations}
+            tableColumns={tableColumns}
+            studyId={studyId}
+            onZoom={this.handleZoom}
+            listTooltip={ListTooltip}
+          />
+        </DownloadSVGPlot>
+        <ManhattanTable
+          loading={loading}
+          error={error}
+          data={associations.filter(assoc => {
+            return start <= assoc.globalPosition && assoc.globalPosition <= end;
+          })}
+          studyId={studyId}
+          filenameStem={`${studyId}-independently-associated-loci`}
+        />
+      </React.Fragment>
+    );
+  }
+}
+
+export default ManhattanContainer;

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -39,6 +39,36 @@ export const tableColumns = studyId => [
         : significantFigures(rowData.pval),
   },
   {
+    id: 'beta',
+    label: 'Beta',
+    tooltip: 'Beta with respect to the ALT allele',
+    renderCell: rowData =>
+      rowData.beta ? significantFigures(rowData.beta) : null,
+  },
+  {
+    id: 'oddsRatio',
+    label: 'Odds Ratio',
+    tooltip: 'Odds ratio with respect to the ALT allele',
+    renderCell: rowData =>
+      rowData.oddsRatio ? significantFigures(rowData.oddsRatio) : null,
+  },
+  {
+    id: 'ci',
+    label: '95% Confidence Interval',
+    tooltip:
+      '95% confidence interval for the effect estimate. CIs are calculated approximately using the reported p-value.',
+    renderCell: rowData =>
+      rowData.beta
+        ? `(${significantFigures(rowData.betaCILower)}, ${significantFigures(
+            rowData.betaCIUpper
+          )})`
+        : rowData.oddsRatio
+          ? `(${significantFigures(
+              rowData.oddsRatioCILower
+            )}, ${significantFigures(rowData.oddsRatioCIUpper)})`
+          : null,
+  },
+  {
     id: 'credibleSetSize',
     label: 'Credible Set Size',
     tooltip: 'Number of variants in 95% credible set at this locus',

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -1,7 +1,12 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
 
-import { OtTable, commaSeparate, significantFigures } from 'ot-ui';
+import {
+  OtTableRF,
+  DataDownloader,
+  commaSeparate,
+  significantFigures,
+} from 'ot-ui';
 import { getCytoband } from 'ot-charts';
 
 import LocusLink from './LocusLink';
@@ -114,6 +119,35 @@ export const tableColumns = studyId => [
   },
 ];
 
+const getDownloadColumns = columns => {
+  return columns.slice(0, columns.length - 1);
+};
+
+const getDownloadData = dataWithCytoband => {
+  return dataWithCytoband.map(row => {
+    return {
+      indexVariantId: row.indexVariantId,
+      indexVariantRsId: row.indexVariantRsId,
+      cytoband: row.cytoband,
+      pval: row.pval,
+      beta: row.beta,
+      oddsRatio: row.oddsRatio,
+      ci: row.beta
+        ? `(${significantFigures(row.betaCILower)}, ${significantFigures(
+            row.betaCIUpper
+          )})`
+        : row.oddsRatio
+          ? `(${significantFigures(row.oddsRatioCILower)}, ${significantFigures(
+              row.oddsRatioCIUpper
+            )})`
+          : null,
+      credibleSetSize: row.credibleSetSize,
+      ldSetSize: row.ldSetSize,
+      bestGenes: row.bestGenes.map(d => d.gene.symbol).join(', '),
+    };
+  });
+};
+
 function ManhattanTable({ loading, error, data, studyId, filenameStem }) {
   const dataWithCytoband = data.map(d => {
     const { chromosome, position } = d;
@@ -122,30 +156,40 @@ function ManhattanTable({ loading, error, data, studyId, filenameStem }) {
       cytoband: getCytoband(chromosome, position),
     };
   });
+  const columns = tableColumns(studyId);
+  const downloadColumns = getDownloadColumns(columns);
+  const downloadData = getDownloadData(dataWithCytoband);
+
   return (
-    <OtTable
-      loading={loading}
-      error={error}
-      columns={tableColumns(studyId)}
-      data={dataWithCytoband}
-      sortBy="pval"
-      order="asc"
-      downloadFileStem={filenameStem}
-      reportTableDownloadEvent={format => {
-        reportAnalyticsEvent({
-          category: 'table',
-          action: 'download',
-          label: `study:manhattan:${format}`,
-        });
-      }}
-      reportTableSortEvent={(sortBy, order) => {
-        reportAnalyticsEvent({
-          category: 'table',
-          action: 'sort-column',
-          label: `study:manhattan:${sortBy}(${order})`,
-        });
-      }}
-    />
+    <Fragment>
+      <DataDownloader
+        tableHeaders={downloadColumns}
+        rows={downloadData}
+        fileStem={filenameStem}
+      />
+      <OtTableRF
+        loading={loading}
+        error={error}
+        columns={columns}
+        data={dataWithCytoband}
+        sortBy="pval"
+        order="asc"
+        reportTableDownloadEvent={format => {
+          reportAnalyticsEvent({
+            category: 'table',
+            action: 'download',
+            label: `study:manhattan:${format}`,
+          });
+        }}
+        reportTableSortEvent={(sortBy, order) => {
+          reportAnalyticsEvent({
+            category: 'table',
+            action: 'sort-column',
+            label: `study:manhattan:${sortBy}(${order})`,
+          });
+        }}
+      />
+    </Fragment>
   );
 }
 

--- a/src/components/OverlapLink.js
+++ b/src/components/OverlapLink.js
@@ -1,18 +1,17 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import queryString from 'query-string';
 import { withStyles } from '@material-ui/core';
 
 import { Button, OverlapIcon } from 'ot-ui';
 
-const mb = 1000000;
-
 const styles = {
   button: {
     lineHeight: 1,
+    minWidth: '110px',
   },
   buttonBig: {
     fontSize: '1.1rem',
+    minWidth: '200px',
     width: '200px',
     height: '40px',
     paddingLeft: '15px',

--- a/src/components/OverlapLink.js
+++ b/src/components/OverlapLink.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import queryString from 'query-string';
+import { withStyles } from '@material-ui/core';
+
+import { Button, OverlapIcon } from 'ot-ui';
+
+const mb = 1000000;
+
+const styles = {
+  button: {
+    lineHeight: 1,
+  },
+  buttonBig: {
+    fontSize: '1.1rem',
+    width: '200px',
+    height: '40px',
+    paddingLeft: '15px',
+  },
+  icon: {
+    stroke: 'white',
+    width: '20px',
+    height: '20px',
+    marginTop: '-5px',
+    marginBottom: '-5px',
+    marginLeft: '5px',
+  },
+  iconBig: {
+    stroke: 'white',
+    width: '30px',
+    height: '30px',
+  },
+  link: {
+    textDecoration: 'none',
+  },
+};
+
+const OverlapLink = ({ big, studyId, classes }) => {
+  return (
+    <Link to={`/study-comparison/${studyId}`} className={classes.link}>
+      <Button gradient className={big ? classes.buttonBig : classes.button}>
+        Compare Studies
+        <OverlapIcon className={big ? classes.iconBig : classes.icon} />
+      </Button>
+    </Link>
+  );
+};
+
+export default withStyles(styles)(OverlapLink);

--- a/src/components/PmidOrBiobankLink.js
+++ b/src/components/PmidOrBiobankLink.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+const PmidOrBiobankLink = ({ studyId, pmid }) =>
+  studyId && studyId.startsWith('NEALE') ? (
+    <a
+      href="http://www.nealelab.is/uk-biobank"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      UK Biobank
+    </a>
+  ) : (
+    <a
+      href={`http://europepmc.org/abstract/med/${pmid}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {pmid}
+    </a>
+  );
+
+export default PmidOrBiobankLink;

--- a/src/components/PmidOrBiobankLink.js
+++ b/src/components/PmidOrBiobankLink.js
@@ -3,7 +3,7 @@ import React from 'react';
 const PmidOrBiobankLink = ({ studyId, pmid }) =>
   studyId && studyId.startsWith('NEALE') ? (
     <a
-      href="http://www.nealelab.is/uk-biobank"
+      href="https://www.nealelab.is/uk-biobank"
       target="_blank"
       rel="noopener noreferrer"
     >
@@ -11,7 +11,7 @@ const PmidOrBiobankLink = ({ studyId, pmid }) =>
     </a>
   ) : (
     <a
-      href={`http://europepmc.org/abstract/med/${pmid}`}
+      href={`https://europepmc.org/abstract/med/${pmid.replace('PMID:', '')}`}
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -41,7 +41,7 @@ class Search extends React.Component {
           history.push(`/gene/${value.id}`);
           break;
         case 'variant':
-          history.push(`/variant/${value.variant.id}`);
+          history.push(`/variant/${value.id}`);
           break;
         case 'study':
           history.push(`/study/${value.studyId}`);

--- a/src/components/SearchOption.js
+++ b/src/components/SearchOption.js
@@ -14,12 +14,7 @@ const Option = ({ data }) => {
         />
       );
     case 'variant':
-      return (
-        <SearchOption
-          heading={data.variant.id}
-          subheading={data.variant.rsId}
-        />
-      );
+      return <SearchOption heading={data.id} subheading={data.rsId} />;
     case 'study':
       const pubYear = new Date(data.pubDate).getFullYear();
       return (

--- a/src/components/SearchOption.js
+++ b/src/components/SearchOption.js
@@ -21,9 +21,12 @@ const Option = ({ data }) => {
         <SearchOption
           heading={data.traitReported}
           subheading={`${data.pubAuthor} (${pubYear})`}
-          extra={`${
-            data.pubJournal ? data.pubJournal : ''
-          } N Study: ${commaSeparate(data.nInitial)}`}
+          extra={
+            <React.Fragment>
+              {data.pubJournal ? <em>{data.pubJournal} </em> : null}N Study:{' '}
+              {commaSeparate(data.nInitial)}
+            </React.Fragment>
+          }
         />
       );
     case 'study-overlap':

--- a/src/components/SearchOption.js
+++ b/src/components/SearchOption.js
@@ -25,6 +25,11 @@ const Option = ({ data }) => {
             <React.Fragment>
               {data.pubJournal ? <em>{data.pubJournal} </em> : null}N Study:{' '}
               {commaSeparate(data.nInitial)}
+              {data.numAssocLoci ? (
+                <span style={{ float: 'right' }}>
+                  <strong>{data.numAssocLoci} associated loci</strong>
+                </span>
+              ) : null}
             </React.Fragment>
           }
         />

--- a/src/components/StudyInfo.js
+++ b/src/components/StudyInfo.js
@@ -4,16 +4,6 @@ const StudyInfo = ({ studyInfo }) => {
   return (
     <div>
       {`${studyInfo.pubAuthor} (${new Date(studyInfo.pubDate).getFullYear()}) `}
-      {studyInfo.pubJournal && <em>{`${studyInfo.pubJournal} `}</em>}
-      {studyInfo.pmid && (
-        <a
-          href={`http://europepmc.org/abstract/med/${studyInfo.pmid}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {studyInfo.pmid}
-        </a>
-      )}
     </div>
   );
 };

--- a/src/components/StudySummary.js
+++ b/src/components/StudySummary.js
@@ -86,8 +86,14 @@ const StudySummary = ({
       {pmid ? (
         <Typography variant="subtitle2">
           <strong>PubMed ID:</strong>{' '}
-          <a href={`http://europepmc.org/abstract/med/${pmid}`} target="_blank">
-            {pmid}
+          <a
+            href={`https://europepmc.org/abstract/med/${pmid.replace(
+              'PMID:',
+              ''
+            )}`}
+            target="_blank"
+          >
+            {pmid.replace('PMID:', '')}
             <Icon
               className={classNames(
                 'fa',

--- a/src/components/StudySummary.js
+++ b/src/components/StudySummary.js
@@ -34,7 +34,14 @@ const styles = () => ({
   },
 });
 
-const StudySummary = ({ classes, nInitial, nReplication, nCases, studyId }) => (
+const StudySummary = ({
+  classes,
+  pmid,
+  nInitial,
+  nReplication,
+  nCases,
+  studyId,
+}) => (
   <Grid container justify="space-between">
     <Grid item xs={12} sm={6} md={8}>
       <Typography variant="subtitle1">External references</Typography>
@@ -57,10 +64,28 @@ const StudySummary = ({ classes, nInitial, nReplication, nCases, studyId }) => (
         <Typography variant="subtitle2">
           <strong>GWAS Catalog:</strong>{' '}
           <a
-            href={`https://www.ebi.ac.uk/gwas/studies/${studyId}`}
+            href={`https://www.ebi.ac.uk/gwas/studies/${studyId.replace(
+              /_\d+/,
+              ''
+            )}`}
             target="_blank"
           >
-            {studyId}
+            {studyId.replace(/_\d+/, '')}
+            <Icon
+              className={classNames(
+                'fa',
+                'fa-external-link-alt',
+                classes.externalLinkIcon
+              )}
+            />
+          </a>
+        </Typography>
+      ) : null}
+      {pmid ? (
+        <Typography variant="subtitle2">
+          <strong>PubMed ID:</strong>{' '}
+          <a href={`http://europepmc.org/abstract/med/${pmid}`} target="_blank">
+            {pmid}
             <Icon
               className={classNames(
                 'fa',

--- a/src/components/StudySummary.js
+++ b/src/components/StudySummary.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import classNames from 'classnames';
+import { withStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import Icon from '@material-ui/core/Icon';
+
+import { Typography, commaSeparate } from 'ot-ui';
+
+const styles = () => ({
+  tooltipIcon: {
+    fontSize: '1.2rem',
+    paddingLeft: `0.6rem`,
+  },
+  valueWithBadgedLabel: {
+    verticalAlign: 'middle',
+    paddingLeft: '0.6rem',
+    paddingRight: '1rem',
+  },
+  value: {
+    paddingLeft: '0.6rem',
+    paddingRight: '1rem',
+  },
+  cardContent: {
+    padding: '8px !important',
+  },
+  externalLinkIcon: {
+    fontSize: '0.7rem',
+    verticalAlign: 'middle',
+    marginLeft: '3px',
+
+    width: '1rem',
+    height: '1rem',
+  },
+});
+
+const StudySummary = ({ classes, nInitial, nReplication, nCases, studyId }) => (
+  <Grid container justify="space-between">
+    <Grid item xs={12} sm={6} md={8}>
+      <Typography variant="subtitle1">External references</Typography>
+      {studyId && studyId.startsWith('NEALEUKB') ? (
+        <Typography variant="subtitle2">
+          <strong>Neale UK Biobank:</strong>{' '}
+          <a href="http://www.nealelab.is/uk-biobank" target="_blank">
+            Homepage
+            <Icon
+              className={classNames(
+                'fa',
+                'fa-external-link-alt',
+                classes.externalLinkIcon
+              )}
+            />
+          </a>
+        </Typography>
+      ) : null}
+      {studyId && studyId.startsWith('GCST') ? (
+        <Typography variant="subtitle2">
+          <strong>GWAS Catalog:</strong>{' '}
+          <a
+            href={`https://www.ebi.ac.uk/gwas/studies/${studyId}`}
+            target="_blank"
+          >
+            {studyId}
+            <Icon
+              className={classNames(
+                'fa',
+                'fa-external-link-alt',
+                classes.externalLinkIcon
+              )}
+            />
+          </a>
+        </Typography>
+      ) : null}
+    </Grid>
+    <Grid item xs={12} sm={6} md={4}>
+      <Typography variant="subtitle1">Study size</Typography>
+      <Grid container>
+        {[
+          { label: 'N Study', value: nInitial },
+          { label: 'N Replication', value: nReplication },
+          { label: 'N Cases', value: nCases },
+        ].map((d, i) => (
+          <React.Fragment key={i}>
+            <Grid item xs={9}>
+              <Typography variant="subtitle2">{d.label}</Typography>
+            </Grid>
+            <Grid item xs={3}>
+              <Typography variant="subtitle2" align="right">
+                {d.value ? commaSeparate(d.value) : 'NA'}
+              </Typography>
+            </Grid>
+          </React.Fragment>
+        ))}
+      </Grid>
+    </Grid>
+  </Grid>
+);
+
+export default withStyles(styles)(StudySummary);

--- a/src/components/StudySummary.js
+++ b/src/components/StudySummary.js
@@ -50,7 +50,11 @@ const StudySummary = ({
       {studyId && studyId.startsWith('NEALEUKB') ? (
         <Typography variant="subtitle2">
           <strong>Neale UK Biobank:</strong>{' '}
-          <a href="http://www.nealelab.is/uk-biobank" target="_blank">
+          <a
+            href="http://www.nealelab.is/uk-biobank"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Homepage
             <Icon
               className={classNames(
@@ -71,6 +75,7 @@ const StudySummary = ({
               ''
             )}`}
             target="_blank"
+            rel="noopener noreferrer"
           >
             {studyId.replace(/_\d+/, '')}
             <Icon
@@ -92,6 +97,7 @@ const StudySummary = ({
               ''
             )}`}
             target="_blank"
+            rel="noopener noreferrer"
           >
             {pmid.replace('PMID:', '')}
             <Icon

--- a/src/components/StudySummary.js
+++ b/src/components/StudySummary.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
@@ -36,6 +35,9 @@ const styles = () => ({
 
 const StudySummary = ({
   classes,
+  pubAuthor,
+  pubDate,
+  pubJournal,
   pmid,
   nInitial,
   nReplication,

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import { unregister } from './registerServiceWorker';
 
 const client = new ApolloClient({
   link: new HttpLink({
-    uri: 'https://open-targets-genetics.appspot.com/graphql',
+    uri: 'https://genetics-api-qa.opentargets.io/graphql',
   }),
   cache: new InMemoryCache(),
 });

--- a/src/logic/transformGenesForVariantSchema.js
+++ b/src/logic/transformGenesForVariantSchema.js
@@ -3,11 +3,11 @@ import React from 'react';
 // TODO: this data should be part of the API response
 const SOURCE_MAP = {
   canonical_tss: {
-    sourceLabel: 'Inverse distance',
+    sourceLabel: 'Distance (Canonical TSS)',
     sourceDescriptionOverview:
-      'Summary of evidence linking this variant to genes using inverse distance to canonical transcription start site.',
+      'Distance from the variant to canonical transcript TSS (kilobases).',
     sourceDescriptionBreakdown:
-      'Evidence linking this variant to genes using inverse distance to canonical transcription start site.',
+      'Distance from the variant to canonical transcript TSS (kilobases).',
     pmid: null,
   },
   gtex_v7: {

--- a/src/logic/transformGenesForVariantSchema.js
+++ b/src/logic/transformGenesForVariantSchema.js
@@ -2,6 +2,14 @@ import React from 'react';
 
 // TODO: this data should be part of the API response
 const SOURCE_MAP = {
+  canonical_tss: {
+    sourceLabel: 'Inverse distance',
+    sourceDescriptionOverview:
+      'Summary of evidence linking this variant to genes using inverse distance to canonical transcription start site.',
+    sourceDescriptionBreakdown:
+      'Evidence linking this variant to genes using inverse distance to canonical transcription start site.',
+    pmid: null,
+  },
   gtex_v7: {
     sourceLabel: 'eQTL (GTEx V7)',
     sourceDescriptionOverview: (
@@ -66,8 +74,9 @@ const SOURCE_MAP = {
 };
 
 const transformGenesForVariantSchema = schema => {
-  const { qtls, intervals, functionalPredictions } = schema;
+  const { distances, qtls, intervals, functionalPredictions } = schema;
   return {
+    distances: distances.map(d => ({ ...d, ...SOURCE_MAP[d.sourceId] })),
     qtls: qtls.map(d => ({ ...d, ...SOURCE_MAP[d.sourceId] })),
     intervals: intervals.map(d => ({ ...d, ...SOURCE_MAP[d.sourceId] })),
     functionalPredictions: functionalPredictions.map(d => ({

--- a/src/logic/transformGenesForVariantSchema.js
+++ b/src/logic/transformGenesForVariantSchema.js
@@ -5,9 +5,9 @@ const SOURCE_MAP = {
   canonical_tss: {
     sourceLabel: 'Distance (Canonical TSS)',
     sourceDescriptionOverview:
-      'Distance from the variant to canonical transcript TSS (kilobases).',
+      'Distance from the variant to canonical transcript TSS (base pairs).',
     sourceDescriptionBreakdown:
-      'Distance from the variant to canonical transcript TSS (kilobases).',
+      'Distance from the variant to canonical transcript TSS (base pairs).',
     pmid: null,
   },
   gtex_v7: {

--- a/src/pages/BasePage.js
+++ b/src/pages/BasePage.js
@@ -1,11 +1,19 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import withStyles from '@material-ui/core/styles/withStyles';
+
 import { Page, NavBar, Footer } from 'ot-ui';
 
 import Search from '../components/Search';
 import { externalLinks } from '../constants';
 
-const BasePage = ({ children }) => (
+const styles = theme => ({
+  page: {
+    marginTop: '20px',
+  },
+});
+
+const BasePage = ({ classes, children }) => (
   <Page
     header={
       <NavBar
@@ -21,8 +29,8 @@ const BasePage = ({ children }) => (
       defaultTitle="Open Targets Genetics"
       titleTemplate="%s | Open Targets Genetics"
     />
-    {children}
+    <div className={classes.page}>{children}</div>
   </Page>
 );
 
-export default BasePage;
+export default withStyles(styles)(BasePage);

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -12,7 +12,6 @@ import {
   SectionHeading,
   Button,
   Typography,
-  LocusIcon,
   OverviewIcon,
   DrugsIcon,
   MouseIcon,
@@ -219,15 +218,11 @@ class GenePage extends React.Component {
                         {isValidGene ? (
                           <Grid item>
                             <LocusLink
+                              big
                               chromosome={chromosome}
                               position={Math.round((start + end) / 2)}
                               selectedGenes={[geneId]}
-                              classes={locusLinkClasses}
-                            >
-                              View associated variants and traits within Locus
-                              View plot
-                              <LocusIcon className={classes.locusIcon} />
-                            </LocusLink>
+                            />
                           </Grid>
                         ) : null}
                       </Grid>

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -396,6 +396,7 @@ class GenePage extends React.Component {
                   authorFilterValue={authorFilterValue}
                   authorFilterOptions={authorFilterOptions}
                   authorFilterHandler={this.handleAuthorFilter}
+                  filenameStem={`${geneId}-studies`}
                 />
               </React.Fragment>
             );

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -134,9 +134,6 @@ class GenePage extends React.Component {
       traitFilter: traitFilterUrl,
       authorFilter: authorFilterUrl,
     } = this._parseQueryProps();
-    const locusLinkClasses = {
-      button: classes.locusLinkButton,
-    };
     return (
       <BasePage>
         <Query query={GENE_PAGE_QUERY} variables={{ geneId }}>

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -34,7 +34,7 @@ function geneData(data) {
 }
 
 function hasAssociatedStudies(data) {
-  return data && data.studiesForGene;
+  return data && data.studiesAndLeadVariantsForGene;
 }
 
 const styles = theme => {
@@ -138,37 +138,37 @@ class GenePage extends React.Component {
             // all
             const associatedStudies =
               isValidGene && hasAssociatedStudies(data)
-                ? data.studiesForGene.map(d => d.study)
+                ? data.studiesAndLeadVariantsForGene
                 : [];
 
             // filtered
             const associatedStudiesFiltered = associatedStudies.filter(d => {
               return (
                 (traitFilterUrl
-                  ? traitFilterUrl.indexOf(d.traitReported) >= 0
+                  ? traitFilterUrl.indexOf(d.study.traitReported) >= 0
                   : true) &&
                 (authorFilterUrl
-                  ? authorFilterUrl.indexOf(d.pubAuthor) >= 0
+                  ? authorFilterUrl.indexOf(d.study.pubAuthor) >= 0
                   : true)
               );
             });
 
             // filters
             const traitFilterOptions = _.sortBy(
-              _.uniq(associatedStudiesFiltered.map(d => d.traitReported)).map(
-                d => ({
-                  label: d,
-                  value: d,
-                  selected: traitFilterUrl
-                    ? traitFilterUrl.indexOf(d) >= 0
-                    : false,
-                })
-              ),
+              _.uniq(
+                associatedStudiesFiltered.map(d => d.study.traitReported)
+              ).map(d => ({
+                label: d,
+                value: d,
+                selected: traitFilterUrl
+                  ? traitFilterUrl.indexOf(d) >= 0
+                  : false,
+              })),
               [d => !d.selected, 'value']
             );
             const traitFilterValue = traitFilterOptions.filter(d => d.selected);
             const authorFilterOptions = _.sortBy(
-              _.uniq(associatedStudiesFiltered.map(d => d.pubAuthor)).map(
+              _.uniq(associatedStudiesFiltered.map(d => d.study.pubAuthor)).map(
                 d => ({
                   label: d,
                   value: d,

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -192,7 +192,7 @@ class GenePage extends React.Component {
               d => d.selected
             );
 
-            const { chromosome, start, end, symbol } = gene;
+            const { chromosome, start, end, symbol, bioType } = gene;
             return (
               <React.Fragment>
                 <Helmet>
@@ -348,18 +348,20 @@ class GenePage extends React.Component {
                             </Button>
                           </a>
                         </Grid>
-                        <Grid item>
-                          <a
-                            className={classes.link}
-                            href={`https://www.uniprot.org/uniprot/?query=${symbol}&sort=score`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            <Button variant="outlined">
-                              UniProt <LinkIcon />
-                            </Button>
-                          </a>
-                        </Grid>
+                        {bioType === 'protein_coding' ? (
+                          <Grid item>
+                            <a
+                              className={classes.link}
+                              href={`https://www.uniprot.org/uniprot/?query=${symbol}&sort=score`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              <Button variant="outlined">
+                                UniProt <LinkIcon />
+                              </Button>
+                            </a>
+                          </Grid>
+                        ) : null}
                         <Grid item>
                           <a
                             className={classes.link}

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -25,18 +25,12 @@ import LocusLink from '../components/LocusLink';
 import AssociatedStudiesTable from '../components/AssociatedStudiesTable';
 import GENE_PAGE_QUERY from '../queries/GenePageQuery.gql';
 
-function hasGeneData(data, geneId) {
-  return (
-    data &&
-    data.search &&
-    data.search.genes &&
-    data.search.genes.length === 1 &&
-    data.search.genes[0].id === geneId
-  );
+function hasGeneData(data) {
+  return data && data.geneInfo;
 }
 
 function geneData(data) {
-  return data.search.genes[0];
+  return data.geneInfo;
 }
 
 function hasAssociatedStudies(data) {

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -25,7 +25,7 @@ const EXAMPLES = [
   { label: 'rs4129267', url: '/variant/1_154426264_C_T', type: 'variant-rsid' },
   {
     label: "Crohn's disease (de Lange KM et al. 2017)",
-    url: '/study/GCST004132',
+    url: '/study/GCST004132_1',
     type: 'study',
   },
 ];

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -24,8 +24,13 @@ const EXAMPLES = [
   },
   { label: 'rs4129267', url: '/variant/1_154426264_C_T', type: 'variant-rsid' },
   {
-    label: "Crohn's disease (de Lange KM et al. 2017)",
-    url: '/study/GCST004132_1',
+    label: 'LDL cholesterol (Klarin D et al. 2018)',
+    url: '/study/GCST006612_1',
+    type: 'study',
+  },
+  {
+    label: "Crohn's disease [EA] (Liu JZ et al. 2015)",
+    url: '/study/GCST003044_1',
     type: 'study',
   },
 ];

--- a/src/pages/StudiesPage.js
+++ b/src/pages/StudiesPage.js
@@ -2,8 +2,6 @@ import React, { Fragment } from 'react';
 import { Helmet } from 'react-helmet';
 import { Query } from 'react-apollo';
 import queryString from 'query-string';
-import Paper from '@material-ui/core/Paper';
-import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import withStyles from '@material-ui/core/styles/withStyles';
 
@@ -13,8 +11,6 @@ import BasePage from './BasePage';
 import ScrollToTop from '../components/ScrollToTop';
 import ManhattansTable from '../components/ManhattansTable';
 import ManhattansVariantsTable from '../components/ManhattansVariantsTable';
-import StudyInfo from '../components/StudyInfo';
-import StudySize from '../components/StudySize';
 import StudyComparisonOption from '../components/StudyComparisonOption';
 import STUDIES_PAGE_QUERY from '../queries/StudiesPageQuery.gql';
 
@@ -260,7 +256,7 @@ class StudiesPage extends React.Component {
     );
   };
   render() {
-    const { classes, match } = this.props;
+    const { match } = this.props;
     const { studyId } = match.params;
     const { studyIds } = this._parseQueryProps();
     return (

--- a/src/pages/StudiesPage.js
+++ b/src/pages/StudiesPage.js
@@ -278,6 +278,7 @@ class StudiesPage extends React.Component {
           {({ loading, error, data }) => {
             const isStudyWithInfo = hasStudyInfo(data);
             const studyInfo = isStudyWithInfo ? getStudyInfo(data) : {};
+            const { pubAuthor, pubDate, pubJournal } = studyInfo;
             const {
               studySelectOptions,
               pileupPseudoStudy,
@@ -295,27 +296,15 @@ class StudiesPage extends React.Component {
             );
             return (
               <Fragment>
-                <Paper className={classes.section}>
-                  <Typography variant="h4" color="textSecondary">
-                    {studyInfo.traitReported}
-                  </Typography>
-                  <Grid container justify="space-between">
-                    <Grid item>
-                      {isStudyWithInfo ? (
-                        <Typography variant="subtitle1">
-                          <StudyInfo studyInfo={data.studyInfo} />
-                        </Typography>
-                      ) : null}
-                    </Grid>
-                    <Grid item>
-                      {isStudyWithInfo ? (
-                        <Typography variant="subtitle1">
-                          <StudySize studyInfo={data.studyInfo} />
-                        </Typography>
-                      ) : null}
-                    </Grid>
-                  </Grid>
-                </Paper>
+                <Typography variant="h4" color="textSecondary">
+                  {studyInfo.traitReported}
+                </Typography>
+                <Typography variant="subtitle1">
+                  {pubAuthor}{' '}
+                  {pubDate ? `(${new Date(pubDate).getFullYear()})` : null}{' '}
+                  {pubJournal ? <em>{pubJournal}</em> : null}
+                </Typography>
+
                 <SectionHeading
                   heading={`Compare overlapping studies`}
                   subheading={

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -124,7 +124,7 @@ class StudyPage extends React.Component {
       end,
     } = this.state;
 
-    const { nInitial, nReplication, nCases } = isStudyWithInfo
+    const { pubJournal, pmid, nInitial, nReplication, nCases } = isStudyWithInfo
       ? data.studyInfo
       : {};
 
@@ -160,7 +160,9 @@ class StudyPage extends React.Component {
           ]}
         />
         {isStudyWithInfo ? (
-          <StudySummary {...{ studyId, nInitial, nReplication, nCases }} />
+          <StudySummary
+            {...{ pubJournal, pmid, studyId, nInitial, nReplication, nCases }}
+          />
         ) : null}
 
         <SectionHeading

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -6,7 +6,7 @@ import Grid from '@material-ui/core/Grid';
 import withStyles from '@material-ui/core/styles/withStyles';
 
 import { Manhattan, chromosomesWithCumulativeLengths } from 'ot-charts';
-import { SectionHeading, Button, DownloadSVGPlot, ListTooltip } from 'ot-ui';
+import { SectionHeading, DownloadSVGPlot, ListTooltip } from 'ot-ui';
 
 import BasePage from './BasePage';
 import ManhattanTable, { tableColumns } from '../components/ManhattanTable';

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -31,7 +31,13 @@ function hasAssociations(data) {
 }
 
 function transformAssociations(data) {
-  return data.manhattan.associations.map(d => {
+  // TODO: API should fix this
+  const zeroPvals = data.manhattan.associations.filter(d => d.pval === 0);
+  if (zeroPvals.length > 0) {
+    console.error('Found zero pvalues in Manhattan data: ', zeroPvals);
+  }
+
+  return data.manhattan.associations.filter(d => d.pval > 0).map(d => {
     const { variant, ...rest } = d;
     const ch = chromosomesWithCumulativeLengths.find(
       ch => ch.name === variant.chromosome

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { withApollo } from 'react-apollo';
 import { Helmet } from 'react-helmet';
-import { Link } from 'react-router-dom';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
@@ -14,9 +13,10 @@ import BasePage from './BasePage';
 import ManhattanTable, { tableColumns } from '../components/ManhattanTable';
 import ScrollToTop from '../components/ScrollToTop';
 import StudyInfo from '../components/StudyInfo';
-import StudySize from '../components/StudySize';
+import OverlapLink from '../components/OverlapLink';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
 import STUDY_PAGE_QUERY from '../queries/StudyPageQuery.gql';
+import StudySummary from '../components/StudySummary';
 
 const SIGNIFICANCE = 5e-8;
 const maxPos =
@@ -124,6 +124,10 @@ class StudyPage extends React.Component {
       end,
     } = this.state;
 
+    const { nInitial, nReplication, nCases } = isStudyWithInfo
+      ? data.studyInfo
+      : {};
+
     return (
       <BasePage>
         <ScrollToTop />
@@ -142,21 +146,23 @@ class StudyPage extends React.Component {
                 </Typography>
               ) : null}
             </Grid>
-            <Grid item>
-              {isStudyWithInfo ? (
-                <Typography variant="subtitle1">
-                  <StudySize studyInfo={data.studyInfo} />
-                </Typography>
-              ) : null}
-            </Grid>
           </Grid>
-          <Link
-            to={`/study-comparison/${studyId}`}
-            style={{ textDecoration: 'none' }}
-          >
-            <Button gradient>Compare to related studies</Button>
-          </Link>
+          <OverlapLink studyId={studyId} />
         </Paper>
+
+        <SectionHeading
+          heading="Study summary"
+          entities={[
+            {
+              type: 'study',
+              fixed: true,
+            },
+          ]}
+        />
+        {isStudyWithInfo ? (
+          <StudySummary {...{ studyId, nInitial, nReplication, nCases }} />
+        ) : null}
+
         <SectionHeading
           heading="Independently-associated loci"
           subheading={

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -1,71 +1,22 @@
 import React from 'react';
-import { withApollo } from 'react-apollo';
+import { Query } from 'react-apollo';
 import { Helmet } from 'react-helmet';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import withStyles from '@material-ui/core/styles/withStyles';
 
-import { Manhattan, chromosomesWithCumulativeLengths } from 'ot-charts';
-import { SectionHeading, DownloadSVGPlot, ListTooltip } from 'ot-ui';
+import { SectionHeading } from 'ot-ui';
 
 import BasePage from './BasePage';
-import ManhattanTable, { tableColumns } from '../components/ManhattanTable';
+
 import ScrollToTop from '../components/ScrollToTop';
 import OverlapLink from '../components/OverlapLink';
-import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
-import STUDY_PAGE_QUERY from '../queries/StudyPageQuery.gql';
+import ManhattanContainer from '../components/ManhattanContainer';
 import StudySummary from '../components/StudySummary';
-
-const SIGNIFICANCE = 5e-8;
-const maxPos =
-  chromosomesWithCumulativeLengths[chromosomesWithCumulativeLengths.length - 1]
-    .cumulativeLength;
-
-function hasAssociations(data) {
-  return (
-    data &&
-    data.manhattan &&
-    data.manhattan.associations &&
-    data.manhattan.associations.length > 0
-  );
-}
-
-function transformAssociations(data) {
-  // TODO: API should fix this
-  const zeroPvals = data.manhattan.associations.filter(d => d.pval === 0);
-  if (zeroPvals.length > 0) {
-    console.error('Found zero pvalues in Manhattan data: ', zeroPvals);
-  }
-
-  return data.manhattan.associations.filter(d => d.pval > 0).map(d => {
-    const { variant, ...rest } = d;
-    const ch = chromosomesWithCumulativeLengths.find(
-      ch => ch.name === variant.chromosome
-    );
-
-    return {
-      ...rest,
-      indexVariantId: variant.id,
-      indexVariantRsId: variant.rsId,
-      chromosome: variant.chromosome,
-      position: variant.position,
-      globalPosition: ch.cumulativeLength - ch.length + variant.position,
-    };
-  });
-}
+import STUDY_PAGE_QUERY from '../queries/StudyPageQuery.gql';
 
 function hasStudyInfo(data) {
   return data && data.studyInfo;
-}
-
-function significantLoci(data) {
-  return hasAssociations(data)
-    ? data.manhattan.associations.filter(d => d.pval < SIGNIFICANCE).length
-    : 0;
-}
-
-function loci(data) {
-  return hasAssociations(data) ? data.manhattan.associations.length : 0;
 }
 
 const styles = theme => ({
@@ -75,153 +26,62 @@ const styles = theme => ({
 });
 
 class StudyPage extends React.Component {
-  state = {
-    loading: true,
-    associations: [],
-    start: 0,
-    end: maxPos,
-  };
-
-  manhattanPlot = React.createRef();
-
-  componentDidMount() {
-    const { client, match } = this.props;
-    const { studyId } = match.params;
-    client
-      .query({
-        query: STUDY_PAGE_QUERY,
-        variables: { studyId },
-        fetchPolicy: 'network-only',
-      })
-      .then(({ data, error }) => {
-        const isAssociatedStudy = hasAssociations(data);
-
-        this.setState({
-          loading: false,
-          error,
-          data,
-          isStudyWithInfo: hasStudyInfo(data),
-          isAssociatedStudy,
-          significantLociCount: significantLoci(data),
-          lociCount: loci(data),
-          associations: isAssociatedStudy ? transformAssociations(data) : [],
-        });
-      });
-  }
-
-  handleZoom = (start, end) => {
-    this.setState({ start, end });
-  };
-
   render() {
     const { classes, match } = this.props;
     const { studyId } = match.params;
-    const {
-      loading,
-      error,
-      associations,
-      isStudyWithInfo,
-      data,
-      significantLociCount,
-      lociCount,
-      start,
-      end,
-    } = this.state;
-
-    const { pubAuthor, pubDate, pubJournal } = isStudyWithInfo
-      ? data.studyInfo
-      : {};
 
     return (
       <BasePage>
-        <ScrollToTop />
-        <Helmet>
-          <title>{studyId}</title>
-        </Helmet>
-        <Grid container justify="space-between">
-          <Grid item>
-            <Typography
-              className={classes.header}
-              variant="h4"
-              color="textSecondary"
-            >
-              {isStudyWithInfo ? data.studyInfo.traitReported : null}
-            </Typography>
-            <Typography variant="subtitle1">
-              {pubAuthor}{' '}
-              {pubDate ? `(${new Date(pubDate).getFullYear()})` : null}{' '}
-              {pubJournal ? <em>{pubJournal}</em> : null}
-            </Typography>
-          </Grid>
-          <Grid item>
-            <OverlapLink big studyId={studyId} />
-          </Grid>
-        </Grid>
+        <Query query={STUDY_PAGE_QUERY} variables={{ studyId }}>
+          {({ loading, error, data }) => {
+            const isStudyWithInfo = hasStudyInfo(data);
+            const { pubAuthor, pubDate, pubJournal } = isStudyWithInfo
+              ? data.studyInfo
+              : {};
+            return (
+              <React.Fragment>
+                <ScrollToTop />
+                <Helmet>
+                  <title>{studyId}</title>
+                </Helmet>
+                <Grid container justify="space-between">
+                  <Grid item>
+                    <Typography
+                      className={classes.header}
+                      variant="h4"
+                      color="textSecondary"
+                    >
+                      {isStudyWithInfo ? data.studyInfo.traitReported : null}
+                    </Typography>
+                    <Typography variant="subtitle1">
+                      {pubAuthor}{' '}
+                      {pubDate ? `(${new Date(pubDate).getFullYear()})` : null}{' '}
+                      {pubJournal ? <em>{pubJournal}</em> : null}
+                    </Typography>
+                  </Grid>
+                  <Grid item>
+                    <OverlapLink big studyId={studyId} />
+                  </Grid>
+                </Grid>
 
-        <SectionHeading
-          heading="Study summary"
-          entities={[
-            {
-              type: 'study',
-              fixed: true,
-            },
-          ]}
-        />
-        {isStudyWithInfo ? <StudySummary {...data.studyInfo} /> : null}
-
-        <SectionHeading
-          heading="Independently-associated loci"
-          subheading={
-            !loading
-              ? `Found ${significantLociCount} loci with genome-wide
-                    significance (p-value < 5e-8) out of ${lociCount}`
-              : null
-          }
-          entities={[
-            {
-              type: 'study',
-              fixed: true,
-            },
-            {
-              type: 'indexVariant',
-              fixed: false,
-            },
-          ]}
-        />
-        <DownloadSVGPlot
-          svgContainer={this.manhattanPlot}
-          loading={loading}
-          error={error}
-          filenameStem={`${studyId}-independently-associated-loci`}
-          reportDownloadEvent={() =>
-            reportAnalyticsEvent({
-              category: 'visualisation',
-              action: 'download',
-              label: `study:manhattan:svg`,
-            })
-          }
-        >
-          <Manhattan
-            ref={this.manhattanPlot}
-            associations={associations}
-            tableColumns={tableColumns}
-            studyId={studyId}
-            onZoom={this.handleZoom}
-            listTooltip={ListTooltip}
-          />
-        </DownloadSVGPlot>
-        <ManhattanTable
-          loading={loading}
-          error={error}
-          data={associations.filter(assoc => {
-            return start <= assoc.globalPosition && assoc.globalPosition <= end;
-          })}
-          studyId={studyId}
-          filenameStem={`${studyId}-independently-associated-loci`}
-        />
+                <SectionHeading
+                  heading="Study summary"
+                  entities={[
+                    {
+                      type: 'study',
+                      fixed: true,
+                    },
+                  ]}
+                />
+                {isStudyWithInfo ? <StudySummary {...data.studyInfo} /> : null}
+                <ManhattanContainer {...{ studyId, loading, error, data }} />
+              </React.Fragment>
+            );
+          }}
+        </Query>
       </BasePage>
     );
   }
 }
 
-export default withApollo(withStyles(styles)(StudyPage));
+export default withStyles(styles)(StudyPage);

--- a/src/pages/StudyPage.js
+++ b/src/pages/StudyPage.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { withApollo } from 'react-apollo';
 import { Helmet } from 'react-helmet';
-import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import withStyles from '@material-ui/core/styles/withStyles';
@@ -12,7 +11,6 @@ import { SectionHeading, Button, DownloadSVGPlot, ListTooltip } from 'ot-ui';
 import BasePage from './BasePage';
 import ManhattanTable, { tableColumns } from '../components/ManhattanTable';
 import ScrollToTop from '../components/ScrollToTop';
-import StudyInfo from '../components/StudyInfo';
 import OverlapLink from '../components/OverlapLink';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
 import STUDY_PAGE_QUERY from '../queries/StudyPageQuery.gql';
@@ -124,7 +122,7 @@ class StudyPage extends React.Component {
       end,
     } = this.state;
 
-    const { pubJournal, pmid, nInitial, nReplication, nCases } = isStudyWithInfo
+    const { pubAuthor, pubDate, pubJournal } = isStudyWithInfo
       ? data.studyInfo
       : {};
 
@@ -134,21 +132,25 @@ class StudyPage extends React.Component {
         <Helmet>
           <title>{studyId}</title>
         </Helmet>
-        <Paper className={classes.section}>
-          <Typography variant="h4" color="textSecondary">
-            {isStudyWithInfo ? data.studyInfo.traitReported : null}
-          </Typography>
-          <Grid container justify="space-between">
-            <Grid item>
-              {isStudyWithInfo ? (
-                <Typography variant="subtitle1">
-                  <StudyInfo studyInfo={data.studyInfo} />
-                </Typography>
-              ) : null}
-            </Grid>
+        <Grid container justify="space-between">
+          <Grid item>
+            <Typography
+              className={classes.header}
+              variant="h4"
+              color="textSecondary"
+            >
+              {isStudyWithInfo ? data.studyInfo.traitReported : null}
+            </Typography>
+            <Typography variant="subtitle1">
+              {pubAuthor}{' '}
+              {pubDate ? `(${new Date(pubDate).getFullYear()})` : null}{' '}
+              {pubJournal ? <em>{pubJournal}</em> : null}
+            </Typography>
           </Grid>
-          <OverlapLink studyId={studyId} />
-        </Paper>
+          <Grid item>
+            <OverlapLink big studyId={studyId} />
+          </Grid>
+        </Grid>
 
         <SectionHeading
           heading="Study summary"
@@ -159,11 +161,7 @@ class StudyPage extends React.Component {
             },
           ]}
         />
-        {isStudyWithInfo ? (
-          <StudySummary
-            {...{ pubJournal, pmid, studyId, nInitial, nReplication, nCases }}
-          />
-        ) : null}
+        {isStudyWithInfo ? <StudySummary {...data.studyInfo} /> : null}
 
         <SectionHeading
           heading="Independently-associated loci"

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -277,6 +277,22 @@ class VariantPage extends React.Component {
                             </Link>
                           </Fragment>
                         ) : null}
+                        {(variantInfo.nearestGene ||
+                          variantInfo.nearestCodingGene) &&
+                        variantInfo.mostSevereConsequence ? (
+                          <br />
+                        ) : null}
+                        {variantInfo.mostSevereConsequence ? (
+                          <Fragment>
+                            Most Severe VEP Consequence:{' '}
+                            <strong>
+                              {variantInfo.mostSevereConsequence.replace(
+                                /_/g,
+                                ' '
+                              )}
+                            </strong>
+                          </Fragment>
+                        ) : null}
                       </Typography>
                     </Grid>
                   </Grid>

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -209,25 +209,6 @@ class VariantPage extends React.Component {
                       >
                         {variantInfo.rsId}
                       </Typography>
-                      <a
-                        className={classes.link}
-                        href={`http://grch37.ensembl.org/Homo_sapiens/Variation/Explore?v=${
-                          variantInfo.rsId
-                        }`}
-                        target="_blank"
-                      >
-                        <Button variant="outlined">Ensembl</Button>
-                      </a>
-                      <a
-                        className={classes.link}
-                        href={`http://gnomad.broadinstitute.org/variant/${variantId.replace(
-                          /_/g,
-                          '-'
-                        )}`}
-                        target="_blank"
-                      >
-                        <Button variant="outlined">gnomAD</Button>
-                      </a>
                     </Grid>
                   </Grid>
                   <Grid container justify="space-between">
@@ -247,54 +228,6 @@ class VariantPage extends React.Component {
                         </LocusLink>
                       ) : null}
                     </Grid>
-                    {/* <Grid item>
-                      <Typography variant="subtitle1">
-                        {variantInfo.nearestGene ? (
-                          <Fragment>
-                            Nearest Gene (
-                            {commaSeparate(variantInfo.nearestGeneDistance)} bp
-                            away):{' '}
-                            <Link to={`/gene/${variantInfo.nearestGene.id}`}>
-                              {variantInfo.nearestGene.symbol}
-                            </Link>
-                          </Fragment>
-                        ) : null}
-                        {variantInfo.nearestGene &&
-                        variantInfo.nearestCodingGene ? (
-                          <br />
-                        ) : null}
-                        {variantInfo.nearestCodingGene ? (
-                          <Fragment>
-                            Nearest Protein-Coding Gene (
-                            {commaSeparate(
-                              variantInfo.nearestCodingGeneDistance
-                            )}{' '}
-                            bp away):{' '}
-                            <Link
-                              to={`/gene/${variantInfo.nearestCodingGene.id}`}
-                            >
-                              {variantInfo.nearestCodingGene.symbol}
-                            </Link>
-                          </Fragment>
-                        ) : null}
-                        {(variantInfo.nearestGene ||
-                          variantInfo.nearestCodingGene) &&
-                        variantInfo.mostSevereConsequence ? (
-                          <br />
-                        ) : null}
-                        {variantInfo.mostSevereConsequence ? (
-                          <Fragment>
-                            Most Severe VEP Consequence:{' '}
-                            <strong>
-                              {variantInfo.mostSevereConsequence.replace(
-                                /_/g,
-                                ' '
-                              )}
-                            </strong>
-                          </Fragment>
-                        ) : null}
-                      </Typography>
-                    </Grid> */}
                   </Grid>
                 </Paper>
                 <SectionHeading
@@ -306,7 +239,9 @@ class VariantPage extends React.Component {
                     },
                   ]}
                 />
-                {isVariantWithInfo ? <GnomADTable data={variantInfo} /> : null}
+                {isVariantWithInfo ? (
+                  <GnomADTable variantId={variantId} data={variantInfo} />
+                ) : null}
                 <SectionHeading
                   heading="Assigned genes"
                   subheading="Which genes are functionally implicated by this variant?"

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -297,18 +297,7 @@ class VariantPage extends React.Component {
                     </Grid>
                   </Grid>
                 </Paper>
-                <SectionHeading
-                  heading="gnomAD summary"
-                  subheading={
-                    <React.Fragment>
-                      Statistics about this variant from{' '}
-                      <a href="https://gnomad.broadinstitute.org/">
-                        the gnomAD project
-                      </a>
-                      .
-                    </React.Fragment>
-                  }
-                />
+                <SectionHeading heading="Variant summary" />
                 {isVariantWithInfo ? <GnomADTable data={variantInfo} /> : null}
                 <SectionHeading
                   heading="Assigned genes"

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -21,6 +21,7 @@ import PlotContainer from 'ot-ui/build/components/PlotContainer';
 import PheWASSection from '../components/PheWASSection';
 
 import VARIANT_PAGE_QUERY from '../queries/VariantPageQuery.gql';
+import GnomADTable from '../components/GnomADTable';
 
 function hasInfo(data) {
   return data && data.variantInfo;
@@ -280,6 +281,19 @@ class VariantPage extends React.Component {
                     </Grid>
                   </Grid>
                 </Paper>
+                <SectionHeading
+                  heading="gnomAD summary"
+                  subheading={
+                    <React.Fragment>
+                      Statistics about this variant from{' '}
+                      <a href="https://gnomad.broadinstitute.org/">
+                        the gnomAD project
+                      </a>
+                      .
+                    </React.Fragment>
+                  }
+                />
+                {isVariantWithInfo ? <GnomADTable data={variantInfo} /> : null}
                 <SectionHeading
                   heading="Assigned genes"
                   subheading="Which genes are functionally implicated by this variant?"

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -4,7 +4,7 @@ import { Helmet } from 'react-helmet';
 import { Query } from 'react-apollo';
 import queryString from 'query-string';
 
-import { SectionHeading, Typography, Button } from 'ot-ui';
+import { SectionHeading, Typography, Button, commaSeparate } from 'ot-ui';
 
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
@@ -250,19 +250,25 @@ class VariantPage extends React.Component {
                       <Typography variant="subtitle1">
                         {variantInfo.nearestGene ? (
                           <Fragment>
-                            Nearest Gene:{' '}
+                            Nearest Gene (
+                            {commaSeparate(variantInfo.nearestGeneDistance)} bp
+                            away):{' '}
                             <Link to={`/gene/${variantInfo.nearestGene.id}`}>
                               {variantInfo.nearestGene.symbol}
                             </Link>
                           </Fragment>
                         ) : null}
                         {variantInfo.nearestGene &&
-                        variantInfo.nearestCodingGene
-                          ? ', '
-                          : null}
+                        variantInfo.nearestCodingGene ? (
+                          <br />
+                        ) : null}
                         {variantInfo.nearestCodingGene ? (
                           <Fragment>
-                            Nearest Protein-Coding Gene:{' '}
+                            Nearest Protein-Coding Gene (
+                            {commaSeparate(
+                              variantInfo.nearestCodingGeneDistance
+                            )}{' '}
+                            bp away):{' '}
                             <Link
                               to={`/gene/${variantInfo.nearestCodingGene.id}`}
                             >

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -247,7 +247,7 @@ class VariantPage extends React.Component {
                         </LocusLink>
                       ) : null}
                     </Grid>
-                    <Grid item>
+                    {/* <Grid item>
                       <Typography variant="subtitle1">
                         {variantInfo.nearestGene ? (
                           <Fragment>
@@ -294,11 +294,11 @@ class VariantPage extends React.Component {
                           </Fragment>
                         ) : null}
                       </Typography>
-                    </Grid>
+                    </Grid> */}
                   </Grid>
                 </Paper>
                 <SectionHeading
-                  heading="Variant summary"
+                  heading="Summary"
                   entities={[
                     {
                       type: 'variant',

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -297,7 +297,15 @@ class VariantPage extends React.Component {
                     </Grid>
                   </Grid>
                 </Paper>
-                <SectionHeading heading="Variant summary" />
+                <SectionHeading
+                  heading="Variant summary"
+                  entities={[
+                    {
+                      type: 'variant',
+                      fixed: true,
+                    },
+                  ]}
+                />
                 {isVariantWithInfo ? <GnomADTable data={variantInfo} /> : null}
                 <SectionHeading
                   heading="Assigned genes"

--- a/src/pages/VariantPage.js
+++ b/src/pages/VariantPage.js
@@ -1,14 +1,14 @@
 import React, { Fragment } from 'react';
-import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { Query } from 'react-apollo';
 import queryString from 'query-string';
 
-import { SectionHeading, Typography, Button, commaSeparate } from 'ot-ui';
+import { SectionHeading, Typography } from 'ot-ui';
 
-import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 import { withStyles } from '@material-ui/core/styles';
+
+import { PlotContainer } from 'ot-ui';
 
 import BasePage from './BasePage';
 import AssociatedTagVariantsTable from '../components/AssociatedTagVariantsTable';
@@ -17,9 +17,7 @@ import AssociatedGenes from '../components/AssociatedGenes';
 import ScrollToTop from '../components/ScrollToTop';
 import LocusLink from '../components/LocusLink';
 import transformGenesForVariantsSchema from '../logic/transformGenesForVariantSchema';
-import PlotContainer from 'ot-ui/build/components/PlotContainer';
 import PheWASSection from '../components/PheWASSection';
-
 import VARIANT_PAGE_QUERY from '../queries/VariantPageQuery.gql';
 import GnomADTable from '../components/GnomADTable';
 
@@ -192,46 +190,36 @@ class VariantPage extends React.Component {
 
             return (
               <Fragment>
-                <Paper className={classes.headerSection}>
-                  <Grid container>
-                    <Grid item>
-                      <Typography
-                        className={classes.header}
-                        variant="h4"
-                        color="textSecondary"
-                      >
-                        {variantId}
-                      </Typography>{' '}
-                      <Typography
-                        className={classes.header}
-                        variant="h6"
-                        color="textSecondary"
-                      >
-                        {variantInfo.rsId}
-                      </Typography>
-                    </Grid>
+                <Grid container justify="space-between">
+                  <Grid item>
+                    <Typography
+                      className={classes.header}
+                      variant="h4"
+                      color="textSecondary"
+                    >
+                      {variantId}
+                    </Typography>
                   </Grid>
-                  <Grid container justify="space-between">
-                    <Grid item>
-                      {isIndexVariant || isTagVariant ? (
-                        <LocusLink
-                          chromosome={chromosome}
-                          position={position}
-                          selectedIndexVariants={
-                            isIndexVariant ? [variantId] : null
-                          }
-                          selectedTagVariants={
-                            isTagVariant && !isIndexVariant ? [variantId] : null
-                          }
-                        >
-                          View locus
-                        </LocusLink>
-                      ) : null}
-                    </Grid>
+                  <Grid item>
+                    {isIndexVariant || isTagVariant ? (
+                      <LocusLink
+                        big
+                        chromosome={chromosome}
+                        position={position}
+                        selectedIndexVariants={
+                          isIndexVariant ? [variantId] : null
+                        }
+                        selectedTagVariants={
+                          isTagVariant && !isIndexVariant ? [variantId] : null
+                        }
+                      >
+                        View locus
+                      </LocusLink>
+                    ) : null}
                   </Grid>
-                </Paper>
+                </Grid>
                 <SectionHeading
-                  heading="Summary"
+                  heading="Variant summary"
                   entities={[
                     {
                       type: 'variant',

--- a/src/queries/GenePageQuery.gql
+++ b/src/queries/GenePageQuery.gql
@@ -7,7 +7,11 @@ query GenePageQuery($geneId: String!) {
     end
     bioType
   }
-  studiesForGene(geneId: $geneId) {
+  studiesAndLeadVariantsForGene(geneId: $geneId) {
+    indexVariant {
+      rsId
+      id
+    }
     study {
       studyId
       traitReported
@@ -18,5 +22,13 @@ query GenePageQuery($geneId: String!) {
       nReplication
       nCases
     }
+    pval
+    oddsRatio
+    oddsRatioCILower
+    oddsRatioCIUpper
+    beta
+    betaCILower
+    betaCIUpper
+    direction
   }
 }

--- a/src/queries/GenePageQuery.gql
+++ b/src/queries/GenePageQuery.gql
@@ -1,13 +1,11 @@
 query GenePageQuery($geneId: String!) {
-  search(queryString: $geneId) {
-    genes {
-      id
-      symbol
-      chromosome
-      start
-      end
-      bioType
-    }
+  geneInfo(geneId: $geneId) {
+    id
+    symbol
+    chromosome
+    start
+    end
+    bioType
   }
   studiesForGene(geneId: $geneId) {
     study {

--- a/src/queries/LocusPageQuery.gql
+++ b/src/queries/LocusPageQuery.gql
@@ -38,6 +38,13 @@ query LocusPageQuery($chromosome: String!, $start: Long!, $end: Long!) {
       r2
       pval
       posteriorProbability
+      oddsRatio
+      oddsRatioCILower
+      oddsRatioCIUpper
+      beta
+      betaCILower
+      betaCIUpper
+      direction
     }
   }
 }

--- a/src/queries/SearchQuery.gql
+++ b/src/queries/SearchQuery.gql
@@ -26,6 +26,7 @@ query SearchQuery($queryString: String!) {
       pubDate
       pubJournal
       nInitial
+      numAssocLoci
     }
   }
 }

--- a/src/queries/SearchQuery.gql
+++ b/src/queries/SearchQuery.gql
@@ -11,14 +11,12 @@ query SearchQuery($queryString: String!) {
       end
     }
     variants {
-      variant {
-        id
-        rsId
-        chromosome
-        position
-        refAllele
-        altAllele
-      }
+      id
+      rsId
+      chromosome
+      position
+      refAllele
+      altAllele
     }
     studies {
       studyId

--- a/src/queries/StudyPageQuery.gql
+++ b/src/queries/StudyPageQuery.gql
@@ -21,6 +21,13 @@ query StudyPageQuery($studyId: String!) {
       pval
       credibleSetSize
       ldSetSize
+      oddsRatio
+      oddsRatioCILower
+      oddsRatioCIUpper
+      beta
+      betaCILower
+      betaCIUpper
+      direction
       bestGenes {
         score
         gene {

--- a/src/queries/VariantPageQuery.gql
+++ b/src/queries/VariantPageQuery.gql
@@ -5,10 +5,12 @@ query VariantPageQuery($variantId: String!) {
       id
       symbol
     }
+    nearestGeneDistance
     nearestCodingGene {
       id
       symbol
     }
+    nearestCodingGeneDistance
   }
   genesForVariantSchema {
     qtls {

--- a/src/queries/VariantPageQuery.gql
+++ b/src/queries/VariantPageQuery.gql
@@ -50,6 +50,14 @@ query VariantPageQuery($variantId: String!) {
         name
       }
     }
+    distances {
+      id
+      sourceId
+      tissues {
+        id
+        name
+      }
+    }
   }
   genesForVariant(variantId: $variantId) {
     gene {
@@ -92,6 +100,19 @@ query VariantPageQuery($variantId: String!) {
         }
         maxEffectLabel
         maxEffectScore
+      }
+    }
+    distances {
+      typeId
+      sourceId
+      aggregatedScore
+      tissues {
+        tissue {
+          id
+          name
+        }
+        score
+        quantile
       }
     }
   }

--- a/src/queries/VariantPageQuery.gql
+++ b/src/queries/VariantPageQuery.gql
@@ -111,6 +111,7 @@ query VariantPageQuery($variantId: String!) {
           id
           name
         }
+        distance
         score
         quantile
       }

--- a/src/queries/VariantPageQuery.gql
+++ b/src/queries/VariantPageQuery.gql
@@ -11,6 +11,9 @@ query VariantPageQuery($variantId: String!) {
       symbol
     }
     nearestCodingGeneDistance
+    mostSevereConsequence
+    caddRaw
+    caddPhred
     gnomadAFR
     gnomadAMR
     gnomadASJ

--- a/src/queries/VariantPageQuery.gql
+++ b/src/queries/VariantPageQuery.gql
@@ -11,6 +11,16 @@ query VariantPageQuery($variantId: String!) {
       symbol
     }
     nearestCodingGeneDistance
+    gnomadAFR
+    gnomadAMR
+    gnomadASJ
+    gnomadEAS
+    gnomadFIN
+    gnomadNFE
+    gnomadNFEEST
+    gnomadNFENWE
+    gnomadNFESEU
+    gnomadOTH
   }
   genesForVariantSchema {
     qtls {

--- a/src/queries/VariantPageQuery.gql
+++ b/src/queries/VariantPageQuery.gql
@@ -134,6 +134,13 @@ query VariantPageQuery($variantId: String!) {
       nTotal
       overallR2
       posteriorProbability
+      oddsRatio
+      oddsRatioCILower
+      oddsRatioCIUpper
+      beta
+      betaCILower
+      betaCIUpper
+      direction
     }
   }
   tagVariantsAndStudiesForIndexVariant(variantId: $variantId) {

--- a/src/utils/generateComparator.js
+++ b/src/utils/generateComparator.js
@@ -1,0 +1,11 @@
+/* 
+Example usage:
+const comparatorDiseaseName = generateComparatorFromAccessor(d => d.disease.name);
+ */
+const generateComparatorFromAccessor = accessor => (a, b) => {
+  const aValue = accessor(a);
+  const bValue = accessor(b);
+  return aValue > bValue ? 1 : aValue === bValue ? 0 : -1;
+};
+
+export default generateComparatorFromAccessor;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5975,9 +5975,9 @@ ot-charts@^0.0.40:
   dependencies:
     lodash.sortby "^4.7.0"
 
-ot-ui@^0.0.72:
-  version "0.0.72"
-  resolved "https://registry.yarnpkg.com/ot-ui/-/ot-ui-0.0.72.tgz#da637eabec4eccf55275c4a28912f47f3f9fc010"
+ot-ui@^0.0.73:
+  version "0.0.73"
+  resolved "https://registry.yarnpkg.com/ot-ui/-/ot-ui-0.0.73.tgz#2acd4ad86f0ddfcf2efa0cf49b1cbdc9b5d8f2b2"
 
 p-finally@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,6 +228,21 @@ address@1.0.3, address@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/address/-/address-1.0.3.tgz#b5f50631f8d6cec8bd20c963963afb55e06cbce9"
 
+airbnb-prop-types@^2.12.0:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/airbnb-prop-types/-/airbnb-prop-types-2.13.1.tgz#abcae3f683c0c918aae5e0a1df6232e39e0abfa5"
+  dependencies:
+    array.prototype.find "^2.0.4"
+    function.prototype.name "^1.1.0"
+    has "^1.0.3"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object.assign "^4.1.0"
+    object.entries "^1.1.0"
+    prop-types "^15.7.2"
+    prop-types-exact "^1.2.0"
+    react-is "^16.8.6"
+
 ajv-keywords@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
@@ -437,6 +452,10 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
+array-filter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-1.0.0.tgz#baf79e62e6ef4c2a4c0b831232daffec251f9d83"
+
 array-filter@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
@@ -485,6 +504,13 @@ array-unique@^0.2.1:
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
+array.prototype.find@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.0.4.tgz#556a5c5362c08648323ddaeb9de9d14bc1864c90"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
 
 array.prototype.flat@^1.2.1:
   version "1.2.1"
@@ -2496,7 +2522,7 @@ default-require-extensions@^1.0.0:
   dependencies:
     strip-bom "^2.0.0"
 
-define-properties@^1.1.2:
+define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   dependencies:
@@ -2804,37 +2830,42 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme-adapter-react-16@^1.2.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.5.0.tgz#50af8d76a45fe0915de932bd95d34cdca75c0be3"
+enzyme-adapter-react-16@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.12.1.tgz#6a2d74c80559d35ac0a91ca162fa45f4186290cf"
   dependencies:
-    enzyme-adapter-utils "^1.8.0"
-    function.prototype.name "^1.1.0"
+    enzyme-adapter-utils "^1.11.0"
     object.assign "^4.1.0"
-    object.values "^1.0.4"
-    prop-types "^15.6.2"
-    react-is "^16.4.2"
+    object.values "^1.1.0"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
     react-test-renderer "^16.0.0-0"
+    semver "^5.6.0"
 
-enzyme-adapter-utils@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.8.0.tgz#ee9f07250663a985f1f2caaf297720787da559f1"
+enzyme-adapter-utils@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.11.0.tgz#6ffff782b1b57dd46c72a845a91fc4103956a117"
   dependencies:
+    airbnb-prop-types "^2.12.0"
     function.prototype.name "^1.1.0"
     object.assign "^4.1.0"
-    prop-types "^15.6.2"
+    object.fromentries "^2.0.0"
+    prop-types "^15.7.2"
+    semver "^5.6.0"
 
-enzyme@^3.4.1:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.6.0.tgz#d213f280a258f61e901bc663d4cc2d6fd9a9dec8"
+enzyme@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.9.0.tgz#2b491f06ca966eb56b6510068c7894a7e0be3909"
   dependencies:
     array.prototype.flat "^1.2.1"
     cheerio "^1.0.0-rc.2"
     function.prototype.name "^1.1.0"
     has "^1.0.3"
+    html-element-map "^1.0.0"
     is-boolean-object "^1.0.0"
     is-callable "^1.1.4"
     is-number-object "^1.0.3"
+    is-regex "^1.0.4"
     is-string "^1.0.4"
     is-subset "^0.1.1"
     lodash.escape "^4.0.1"
@@ -2870,6 +2901,17 @@ es-abstract@^1.10.0, es-abstract@^1.5.0, es-abstract@^1.6.1, es-abstract@^1.7.0:
     is-callable "^1.1.3"
     is-regex "^1.0.4"
 
+es-abstract@^1.11.0, es-abstract@^1.12.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-keys "^1.0.12"
+
 es-to-primitive@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
@@ -2877,6 +2919,14 @@ es-to-primitive@^1.1.1:
     is-callable "^1.1.1"
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
+
+es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.46"
@@ -3947,6 +3997,12 @@ html-comment-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
 
+html-element-map@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/html-element-map/-/html-element-map-1.0.1.tgz#3c4fcb4874ebddfe4283b51c8994e7713782b592"
+  dependencies:
+    array-filter "^1.0.0"
+
 html-encoding-sniffer@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -4497,6 +4553,12 @@ is-svg@^2.0.0:
 is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
+
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -5292,7 +5354,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -5848,6 +5910,24 @@ object.entries@^1.0.4:
     function-bind "^1.1.0"
     has "^1.0.1"
 
+object.entries@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.0.tgz#2024fc6d6ba246aee38bdb0ffd5cfbcf371b7519"
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.12.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+
+object.fromentries@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.0.tgz#49a543d92151f8277b3ac9600f1e930b189d30ab"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.11.0"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
@@ -5869,6 +5949,15 @@ object.values@^1.0.4:
     es-abstract "^1.6.1"
     function-bind "^1.1.0"
     has "^1.0.1"
+
+object.values@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.0.tgz#bf6810ef5da3e5325790eaaa2be213ea84624da9"
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.12.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
 
 obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.2"
@@ -5978,7 +6067,6 @@ ot-charts@^0.0.40:
 ot-ui@^0.0.77:
   version "0.0.77"
   resolved "https://registry.yarnpkg.com/ot-ui/-/ot-ui-0.0.77.tgz#c0f7caa8b11657373fe0f022b1a17b3e1415a2e1"
-  integrity sha512-cB+cRCfMZv8LgS8oyJ+DtqNGyisOTJ+iN+/rlaQVKrRHfGw1UNRC/3H7CfInd666O2F+FZ/KFospZUYOjtlSBA==
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -6585,12 +6673,28 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types-exact@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prop-types-exact/-/prop-types-exact-1.2.0.tgz#825d6be46094663848237e3925a98c6e944e9869"
+  dependencies:
+    has "^1.0.3"
+    object.assign "^4.1.0"
+    reflect.ownkeys "^0.2.0"
+
 prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 proxy-addr@~2.0.3:
   version "2.0.4"
@@ -6831,9 +6935,13 @@ react-is@^16.3.2:
   version "16.6.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.1.tgz#f77b1c3d901be300abe8d58645b7a59e794e5982"
 
-react-is@^16.4.2, react-is@^16.5.0:
+react-is@^16.5.0:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.0.tgz#2ec7c192709698591efe13722fab3ef56144ba55"
+
+react-is@^16.8.1, react-is@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
 
 react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -7086,6 +7194,10 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+reflect.ownkeys@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
 
 regenerate@^1.2.1:
   version "1.4.0"
@@ -7441,6 +7553,10 @@ semver-diff@^2.0.0:
 "semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
+
+semver@^5.6.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
 
 send@0.16.2:
   version "0.16.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5975,10 +5975,9 @@ ot-charts@^0.0.40:
   dependencies:
     lodash.sortby "^4.7.0"
 
-ot-ui@^0.0.69:
-  version "0.0.69"
-  resolved "https://registry.yarnpkg.com/ot-ui/-/ot-ui-0.0.69.tgz#eb9bb445eee9e85bdb796e572102a01b10c9f673"
-  integrity sha512-1pxuZDcsbhm2LsPsz7HBKKBmnSmx0+4LCKapluS5hQaPM6QqAkeB9rJerBZhWZcLrdpwLsgj2XBPFmmvhSpc5A==
+ot-ui@^0.0.72:
+  version "0.0.72"
+  resolved "https://registry.yarnpkg.com/ot-ui/-/ot-ui-0.0.72.tgz#da637eabec4eccf55275c4a28912f47f3f9fc010"
 
 p-finally@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds changes needed for the v2 release. This includes:
* on gene page
  * use `geneInfo` query instead of `search` for basic gene information
  * use `studiesAndLeadVariantsForGene` query instead of `studiesForGene` for associated studies table
* on variant page
  * add cadd score, subpopulation allele frequencies
  * add distance to associated genes table
  * add aggregate column to relevant subtabs of associated genes table
* on several pages
  * add beta, odds ratio and confidence intervals to several tables
