### PR TITLE
Support environment variable for GraphQL API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ yarn-debug.log*
 yarn-error.log*
 
 # for vim users
+mock-data
 *.swp

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,10 @@
   to = "https://genetics.opentargets.org/:splat"
   status = 301
   force = true
+
+# qa and dev branches to use different apis
+# (as per https://github.com/opentargets/genetics/issues/312)
+[context.qa.environment]
+  REACT_APP_GRAPHQL_API_URL = "https://genetics-api-qa.opentargets.io"
+[context.dev.environment]
+  REACT_APP_GRAPHQL_API_URL = "https://open-targets-genetics.appspot.com"

--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,14 @@ import { HttpLink } from 'apollo-link-http';
 import App from './App';
 import { unregister } from './registerServiceWorker';
 
+const apiUrlDefault = 'https://genetics-api.opentargets.io';
+const apiUrl = process.env.REACT_APP_GRAPHQL_API_URL
+  ? process.env.REACT_APP_GRAPHQL_API_URL
+  : apiUrlDefault;
+
 const client = new ApolloClient({
   link: new HttpLink({
-    uri: 'https://genetics-api.opentargets.io/graphql',
+    uri: `${apiUrl}/graphql`,
   }),
   cache: new InMemoryCache(),
 });


### PR DESCRIPTION
This PR adds support for an environment variable `REACT_APP_GRAPHQL_API_URL`, which can be used within Netlify to switch the GraphQL API depending on the branch. If not set, the default is https://genetics-api.opentargets.io, which is assumed to be the most stable.