### PR TITLE
Harmonise use of hyperlinks

### DIFF
--- a/src/components/AssociatedGenes.js
+++ b/src/components/AssociatedGenes.js
@@ -1,8 +1,8 @@
 import React, { Component, Fragment } from 'react';
-import { Link } from 'react-router-dom';
 import * as d3 from 'd3';
 
 import {
+  Link,
   DataDownloader,
   OtTableRF,
   Tabs,

--- a/src/components/AssociatedIndexVariantsTable.js
+++ b/src/components/AssociatedIndexVariantsTable.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { OtTable, commaSeparate, significantFigures } from 'ot-ui';
+import { OtTable, commaSeparate, significantFigures, Link } from 'ot-ui';
 
 import { pvalThreshold } from '../constants';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
@@ -47,14 +46,13 @@ const tableColumns = variantId => [
     tooltip: (
       <React.Fragment>
         Beta with respect to the ALT allele.
-        <a
-          style={{ color: 'white' }}
-          href="https://genetics-docs.opentargets.org/faqs#why-are-betas-and-odds-ratios-displayed-inconsistently-in-the-portal"
-          target="_blank"
-          rel="noopener noreferrer"
+        <Link
+          external
+          tooltip
+          to="https://genetics-docs.opentargets.org/faqs#why-are-betas-and-odds-ratios-displayed-inconsistently-in-the-portal"
         >
           See FAQ.
-        </a>
+        </Link>
       </React.Fragment>
     ),
     renderCell: rowData =>

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import {
   DataDownloader,
   OtTableRF,
   commaSeparate,
   significantFigures,
   Autocomplete,
+  Link,
 } from 'ot-ui';
 
 import { pvalThreshold } from '../constants';
@@ -167,14 +167,13 @@ const tableColumns = ({
     tooltip: (
       <React.Fragment>
         Beta with respect to the ALT allele.
-        <a
-          style={{ color: 'white' }}
-          href="https://genetics-docs.opentargets.org/faqs#why-are-betas-and-odds-ratios-displayed-inconsistently-in-the-portal"
-          target="_blank"
-          rel="noopener noreferrer"
+        <Link
+          external
+          tooltip
+          to="https://genetics-docs.opentargets.org/faqs#why-are-betas-and-odds-ratios-displayed-inconsistently-in-the-portal"
         >
           See FAQ.
-        </a>
+        </Link>
       </React.Fragment>
     ),
     renderCell: rowData =>

--- a/src/components/AssociatedTagVariantsTable.js
+++ b/src/components/AssociatedTagVariantsTable.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { OtTable, commaSeparate, significantFigures } from 'ot-ui';
+import { Link, OtTable, commaSeparate, significantFigures } from 'ot-ui';
 
 import { pvalThreshold } from '../constants';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';

--- a/src/components/GnomADTable.js
+++ b/src/components/GnomADTable.js
@@ -1,11 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
-import Icon from '@material-ui/core/Icon';
 
-import { Typography, commaSeparate } from 'ot-ui';
+import { Link, Typography, commaSeparate } from 'ot-ui';
 
 const populations = [
   { code: 'AFR', description: 'African/African-American' },
@@ -24,29 +21,9 @@ const populations = [
 ];
 
 const styles = () => ({
-  tooltipIcon: {
-    fontSize: '1.2rem',
-    paddingLeft: `0.6rem`,
-  },
-  valueWithBadgedLabel: {
-    verticalAlign: 'middle',
-    paddingLeft: '0.6rem',
-    paddingRight: '1rem',
-  },
   value: {
     paddingLeft: '0.6rem',
     paddingRight: '1rem',
-  },
-  cardContent: {
-    padding: '8px !important',
-  },
-  externalLinkIcon: {
-    fontSize: '0.7rem',
-    verticalAlign: 'middle',
-    marginLeft: '3px',
-
-    width: '1rem',
-    height: '1rem',
   },
 });
 
@@ -56,43 +33,27 @@ const GnomADTable = ({ classes, data, variantId }) => (
       <Typography variant="subtitle1">External references</Typography>
       <Typography variant="subtitle2">
         <strong>Ensembl:</strong>{' '}
-        <a
-          href={`http://grch37.ensembl.org/Homo_sapiens/Variation/Explore?v=${
+        <Link
+          external
+          to={`http://grch37.ensembl.org/Homo_sapiens/Variation/Explore?v=${
             data.rsId
           }`}
-          target="_blank"
-          rel="noopener noreferrer"
         >
           {data.rsId}
-          <Icon
-            className={classNames(
-              'fa',
-              'fa-external-link-alt',
-              classes.externalLinkIcon
-            )}
-          />
-        </a>
+        </Link>
       </Typography>
       <Typography variant="subtitle2">
         <strong>gnomAD:</strong>{' '}
         {variantId ? (
-          <a
-            href={`http://gnomad.broadinstitute.org/variant/${variantId.replace(
+          <Link
+            external
+            to={`http://gnomad.broadinstitute.org/variant/${variantId.replace(
               /_/g,
               '-'
             )}`}
-            target="_blank"
-            rel="noopener noreferrer"
           >
             {variantId.replace(/_/g, '-')}
-            <Icon
-              className={classNames(
-                'fa',
-                'fa-external-link-alt',
-                classes.externalLinkIcon
-              )}
-            />
-          </a>
+          </Link>
         ) : null}
       </Typography>
       <br />
@@ -120,20 +81,12 @@ const GnomADTable = ({ classes, data, variantId }) => (
 
       <Typography variant="subtitle1">
         Variant Effect Predictor (
-        <a
-          href="https://www.ensembl.org/info/docs/tools/vep/index.html"
-          target="_blank"
-          rel="noopener noreferrer"
+        <Link
+          external
+          to="https://www.ensembl.org/info/docs/tools/vep/index.html"
         >
           VEP
-          <Icon
-            className={classNames(
-              'fa',
-              'fa-external-link-alt',
-              classes.externalLinkIcon
-            )}
-          />
-        </a>
+        </Link>
         )
       </Typography>
       <Typography variant="subtitle2">
@@ -144,20 +97,9 @@ const GnomADTable = ({ classes, data, variantId }) => (
 
       <Typography variant="subtitle1">
         Combined Annotation Dependent Depletion (
-        <a
-          href="https://cadd.gs.washington.edu/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <Link external to="https://cadd.gs.washington.edu/">
           CADD
-          <Icon
-            className={classNames(
-              'fa',
-              'fa-external-link-alt',
-              classes.externalLinkIcon
-            )}
-          />
-        </a>
+        </Link>
         )
       </Typography>
       <Typography variant="subtitle2">
@@ -170,20 +112,9 @@ const GnomADTable = ({ classes, data, variantId }) => (
     <Grid item xs={12} sm={6} md={4}>
       <Typography variant="subtitle1">
         Population allele frequencies (
-        <a
-          href="https://gnomad.broadinstitute.org/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <Link external to="https://gnomad.broadinstitute.org/">
           gnomAD
-          <Icon
-            className={classNames(
-              'fa',
-              'fa-external-link-alt',
-              classes.externalLinkIcon
-            )}
-          />
-        </a>
+        </Link>
         )
       </Typography>
       <Grid container>

--- a/src/components/LocusLink.js
+++ b/src/components/LocusLink.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import queryString from 'query-string';
 import { withStyles } from '@material-ui/core';
 
-import { Button, LocusIcon } from 'ot-ui';
+import { Link, Button, LocusIcon } from 'ot-ui';
 import { chromosomesWithCumulativeLengths } from 'ot-charts';
 
 const chromosomeDict = chromosomesWithCumulativeLengths.reduce((acc, d) => {

--- a/src/components/LocusTable.js
+++ b/src/components/LocusTable.js
@@ -1,7 +1,12 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import * as d3 from 'd3';
-import { OtTable, DataCircle, significantFigures, Autocomplete } from 'ot-ui';
+import {
+  Link,
+  OtTable,
+  DataCircle,
+  significantFigures,
+  Autocomplete,
+} from 'ot-ui';
 
 import { pvalThreshold } from '../constants';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
@@ -122,14 +127,13 @@ export const tableColumns = ({
     tooltip: (
       <React.Fragment>
         Beta with respect to the ALT allele.
-        <a
-          style={{ color: 'white' }}
-          href="https://genetics-docs.opentargets.org/faqs#why-are-betas-and-odds-ratios-displayed-inconsistently-in-the-portal"
-          target="_blank"
-          rel="noopener noreferrer"
+        <Link
+          external
+          tooltip
+          to="https://genetics-docs.opentargets.org/faqs#why-are-betas-and-odds-ratios-displayed-inconsistently-in-the-portal"
         >
           See FAQ.
-        </a>
+        </Link>
       </React.Fragment>
     ),
     renderCell: rowData =>

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
-import { Link } from 'react-router-dom';
 
 import {
+  Link,
   OtTableRF,
   DataDownloader,
   commaSeparate,
@@ -49,14 +49,13 @@ export const tableColumns = studyId => [
     tooltip: (
       <React.Fragment>
         Beta with respect to the ALT allele.
-        <a
-          style={{ color: 'white' }}
-          href="https://genetics-docs.opentargets.org/faqs#why-are-betas-and-odds-ratios-displayed-inconsistently-in-the-portal"
-          target="_blank"
-          rel="noopener noreferrer"
+        <Link
+          external
+          tooltip
+          to="https://genetics-docs.opentargets.org/faqs#why-are-betas-and-odds-ratios-displayed-inconsistently-in-the-portal"
         >
           See FAQ.
-        </a>
+        </Link>
       </React.Fragment>
     ),
     renderCell: rowData =>

--- a/src/components/ManhattansTable.js
+++ b/src/components/ManhattansTable.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { OtTable, CloseButton, commaSeparate } from 'ot-ui';
+import { Link, OtTable, CloseButton, commaSeparate } from 'ot-ui';
 import { ManhattanFlat } from 'ot-charts';
 
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';

--- a/src/components/ManhattansVariantsTable.js
+++ b/src/components/ManhattansVariantsTable.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-import { OtTable } from 'ot-ui';
+import { Link, OtTable } from 'ot-ui';
 import { getCytoband } from 'ot-charts';
 
 import LocusLink from './LocusLink';

--- a/src/components/OverlapLink.js
+++ b/src/components/OverlapLink.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { withStyles } from '@material-ui/core';
 
-import { Button, OverlapIcon } from 'ot-ui';
+import { Link, Button, OverlapIcon } from 'ot-ui';
 
 const styles = {
   button: {

--- a/src/components/PheWASTable.js
+++ b/src/components/PheWASTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import {
+  Link,
   OtTable,
   commaSeparate,
   significantFigures,

--- a/src/components/PmidOrBiobankLink.js
+++ b/src/components/PmidOrBiobankLink.js
@@ -1,22 +1,18 @@
 import React from 'react';
+import { Link } from 'ot-ui';
 
 const PmidOrBiobankLink = ({ studyId, pmid }) =>
   studyId && studyId.startsWith('NEALE') ? (
-    <a
-      href="https://www.nealelab.is/uk-biobank"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+    <Link external to="https://www.nealelab.is/uk-biobank">
       UK Biobank
-    </a>
+    </Link>
   ) : (
-    <a
-      href={`https://europepmc.org/abstract/med/${pmid.replace('PMID:', '')}`}
-      target="_blank"
-      rel="noopener noreferrer"
+    <Link
+      external
+      to={`https://europepmc.org/abstract/med/${pmid.replace('PMID:', '')}`}
     >
       {pmid}
-    </a>
+    </Link>
   );
 
 export default PmidOrBiobankLink;

--- a/src/components/StudySummary.js
+++ b/src/components/StudySummary.js
@@ -1,35 +1,13 @@
 import React from 'react';
-import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
-import Icon from '@material-ui/core/Icon';
 
-import { Typography, commaSeparate } from 'ot-ui';
+import { Link, Typography, commaSeparate } from 'ot-ui';
 
 const styles = () => ({
-  tooltipIcon: {
-    fontSize: '1.2rem',
-    paddingLeft: `0.6rem`,
-  },
-  valueWithBadgedLabel: {
-    verticalAlign: 'middle',
-    paddingLeft: '0.6rem',
-    paddingRight: '1rem',
-  },
   value: {
     paddingLeft: '0.6rem',
     paddingRight: '1rem',
-  },
-  cardContent: {
-    padding: '8px !important',
-  },
-  externalLinkIcon: {
-    fontSize: '0.7rem',
-    verticalAlign: 'middle',
-    marginLeft: '3px',
-
-    width: '1rem',
-    height: '1rem',
   },
 });
 
@@ -50,64 +28,37 @@ const StudySummary = ({
       {studyId && studyId.startsWith('NEALEUKB') ? (
         <Typography variant="subtitle2">
           <strong>Neale UK Biobank:</strong>{' '}
-          <a
-            href="http://www.nealelab.is/uk-biobank"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <Link external to="http://www.nealelab.is/uk-biobank">
             Homepage
-            <Icon
-              className={classNames(
-                'fa',
-                'fa-external-link-alt',
-                classes.externalLinkIcon
-              )}
-            />
-          </a>
+          </Link>
         </Typography>
       ) : null}
       {studyId && studyId.startsWith('GCST') ? (
         <Typography variant="subtitle2">
           <strong>GWAS Catalog:</strong>{' '}
-          <a
-            href={`https://www.ebi.ac.uk/gwas/studies/${studyId.replace(
+          <Link
+            external
+            to={`https://www.ebi.ac.uk/gwas/studies/${studyId.replace(
               /_\d+/,
               ''
             )}`}
-            target="_blank"
-            rel="noopener noreferrer"
           >
             {studyId.replace(/_\d+/, '')}
-            <Icon
-              className={classNames(
-                'fa',
-                'fa-external-link-alt',
-                classes.externalLinkIcon
-              )}
-            />
-          </a>
+          </Link>
         </Typography>
       ) : null}
       {pmid ? (
         <Typography variant="subtitle2">
           <strong>PubMed ID:</strong>{' '}
-          <a
-            href={`https://europepmc.org/abstract/med/${pmid.replace(
+          <Link
+            external
+            to={`https://europepmc.org/abstract/med/${pmid.replace(
               'PMID:',
               ''
             )}`}
-            target="_blank"
-            rel="noopener noreferrer"
           >
             {pmid.replace('PMID:', '')}
-            <Icon
-              className={classNames(
-                'fa',
-                'fa-external-link-alt',
-                classes.externalLinkIcon
-              )}
-            />
-          </a>
+          </Link>
         </Typography>
       ) : null}
     </Grid>

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -6,7 +6,7 @@ import Typography from '@material-ui/core/Typography';
 import withStyles from '@material-ui/core/styles/withStyles';
 import RootRef from '@material-ui/core/RootRef';
 
-import { Splash, HomeBox, Footer, Button, NavBar } from 'ot-ui';
+import { Splash, HomeBox, Footer, Button, NavBar, Link } from 'ot-ui';
 
 import Search from '../components/Search';
 import PortalFeaturesIcon from '../components/PortalFeaturesIcon';
@@ -147,13 +147,9 @@ class HomePage extends Component {
                 ))}
               </Grid>
               <Typography style={{ marginTop: '25px', textAlign: 'center' }}>
-                <a
-                  href="http://eepurl.com/dHnchn"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+                <Link external to="http://eepurl.com/dHnchn">
                   Subscribe to our newsletter
-                </a>
+                </Link>
               </Typography>
             </HomeBox>
             <Grid container item justify="center">


### PR DESCRIPTION
This PR rolls out the use of the `Link` component from `ot-ui` for consistent usage of hyperlinks.