### PR TITLE
Study-locus page tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "graphql": "^0.13.2",
     "lodash": "^4.17.10",
     "ot-charts": "^0.0.41",
-    "ot-ui": "^0.0.82",
+    "ot-ui": "^0.0.84",
     "polished": "^2.1.1",
     "query-string": "5",
     "react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "file-saver": "^1.3.8",
     "graphql": "^0.13.2",
     "lodash": "^4.17.10",
-    "ot-charts": "^0.0.41",
+    "ot-charts": "^0.0.43",
     "ot-ui": "^0.0.84",
     "polished": "^2.1.1",
     "query-string": "5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.3",
     "@material-ui/icons": "^3.0.2",
+    "@material-ui/lab": "^3.0.0-alpha.30",
     "apollo-cache-inmemory": "^1.2.5",
     "apollo-client": "^2.3.5",
     "apollo-link-http": "^1.5.4",

--- a/src/components/ColocGWASTable.js
+++ b/src/components/ColocGWASTable.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Link, OtTable, Button, significantFigures } from 'ot-ui';
+import { Link, OtTable, significantFigures } from 'ot-ui';
 
-const tableColumns = handleToggleRegional => [
+const tableColumns = [
   {
     id: 'study',
     label: 'Study',
@@ -35,33 +35,13 @@ const tableColumns = handleToggleRegional => [
     label: 'log(H4/H3)',
     renderCell: d => significantFigures(d.logH4H3),
   },
-  {
-    id: 'show',
-    label: 'Regional Plot',
-    renderCell: d =>
-      d.isShowingRegional ? (
-        <Button gradient onClick={() => handleToggleRegional(d)}>
-          Hide
-        </Button>
-      ) : (
-        <Button gradient onClick={() => handleToggleRegional(d)}>
-          Show
-        </Button>
-      ),
-  },
 ];
 
-const ColocTable = ({
-  loading,
-  error,
-  filenameStem,
-  data,
-  handleToggleRegional,
-}) => (
+const ColocTable = ({ loading, error, filenameStem, data }) => (
   <OtTable
     loading={loading}
     error={error}
-    columns={tableColumns(handleToggleRegional)}
+    columns={tableColumns}
     data={data}
     sortBy="logH4H3"
     order="desc"

--- a/src/components/ColocQTLTable.js
+++ b/src/components/ColocQTLTable.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Link, OtTable, Button, significantFigures } from 'ot-ui';
+import { Link, OtTable, significantFigures } from 'ot-ui';
 
-const tableColumns = handleToggleRegional => [
+const tableColumns = [
   {
     id: 'type',
     label: 'Molecular Trait',
@@ -42,33 +42,13 @@ const tableColumns = handleToggleRegional => [
     label: 'log(H4/H3)',
     renderCell: d => significantFigures(d.logH4H3),
   },
-  {
-    id: 'show',
-    label: 'Regional Plot',
-    renderCell: d =>
-      d.isShowingRegional ? (
-        <Button gradient onClick={() => handleToggleRegional(d)}>
-          Hide
-        </Button>
-      ) : (
-        <Button gradient onClick={() => handleToggleRegional(d)}>
-          Show
-        </Button>
-      ),
-  },
 ];
 
-const ColocTable = ({
-  loading,
-  error,
-  filenameStem,
-  data,
-  handleToggleRegional,
-}) => (
+const ColocTable = ({ loading, error, filenameStem, data }) => (
   <OtTable
     loading={loading}
     error={error}
-    columns={tableColumns(handleToggleRegional)}
+    columns={tableColumns}
     data={data}
     sortBy="logH4H3"
     order="desc"

--- a/src/components/CredibleSetWithRegional.js
+++ b/src/components/CredibleSetWithRegional.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { withStyles } from '@material-ui/core/styles';
+import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+
+import { CredibleSet, Regional } from 'ot-charts';
+
+const styles = () => ({
+  container: {
+    width: '100%',
+    maxWidth: '100%',
+  },
+});
+
+const CredibleSetWithRegional = ({
+  classes,
+  credibleSetProps,
+  regionalProps,
+}) => (
+  <ExpansionPanel>
+    <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+      <div className={classes.container}>
+        <CredibleSet {...credibleSetProps} />
+      </div>
+    </ExpansionPanelSummary>
+    <ExpansionPanelDetails>
+      <div className={classes.container}>
+        <Regional {...regionalProps} />
+      </div>
+    </ExpansionPanelDetails>
+  </ExpansionPanel>
+);
+
+export default withStyles(styles)(CredibleSetWithRegional);

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import MuiSlider from '@material-ui/lab/Slider';
+import Grid from '@material-ui/core/Grid';
+
+const styles = {
+  root: {
+    width: 200,
+    padding: '0 20px',
+  },
+  sliderContainer: {
+    padding: '10px 5px 8px 5px',
+  },
+  min: {
+    fontSize: '0.7rem',
+  },
+  max: {
+    fontSize: '0.7rem',
+  },
+};
+
+const Slider = ({ classes, label, value, min, max, step, onChange }) => {
+  return (
+    <div className={classes.root}>
+      <Typography>{label}</Typography>
+      <div className={classes.sliderContainer}>
+        <MuiSlider
+          classes={{ container: classes.slider }}
+          {...{ value, min, max, step, onChange }}
+        />
+      </div>
+
+      <Grid container justify="space-between">
+        <Grid item>
+          <Typography className={classes.min}>{min}</Typography>
+        </Grid>
+        <Grid item>
+          <Typography className={classes.max}>{max}</Typography>
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
+
+export default withStyles(styles)(Slider);

--- a/src/pages/LocusTraitPage.js
+++ b/src/pages/LocusTraitPage.js
@@ -13,7 +13,7 @@ import {
   PlotContainer,
   PlotContainerSection,
 } from 'ot-ui';
-import { CredibleSet, Regional, GeneTrack } from 'ot-charts';
+import { GeneTrack } from 'ot-charts';
 
 import BasePage from './BasePage';
 import ColocQTLTable from '../components/ColocQTLTable';
@@ -127,7 +127,6 @@ class LocusTraitPage extends React.Component {
   state = {
     qtlTabsValue: 'heatmap',
     gwasTabsValue: 'heatmap',
-    regionals: [],
     credSet95Value: 'all',
   };
   handleQtlTabsChange = (_, qtlTabsValue) => {
@@ -136,60 +135,15 @@ class LocusTraitPage extends React.Component {
   handleGWASTabsChange = (_, gwasTabsValue) => {
     this.setState({ gwasTabsValue });
   };
-  handleToggleRegional = d => {
-    const { regionals } = this.state;
-    const index = regionals.findIndex(
-      r =>
-        r.study === d.study &&
-        r.phenotype === d.phenotype &&
-        r.bioFeature === d.bioFeature &&
-        r.chrom === d.chrom &&
-        r.pos === d.pos &&
-        r.ref === d.ref &&
-        r.alt === d.alt
-    );
-    if (index >= 0) {
-      const regionalsWithoutD = [
-        ...regionals.slice(0, index),
-        ...regionals.slice(index + 1),
-      ];
-      this.setState({ regionals: regionalsWithoutD });
-    } else {
-      const { isShowingRegional, ...dWithoutIsShowingRegional } = d;
-      this.setState({ regionals: [...regionals, dWithoutIsShowingRegional] });
-    }
-  };
   handleCredSet95Change = event => {
     this.setState({ credSet95Value: event.target.value });
   };
   render() {
     const { regionals } = this.state;
-    const colocQtlTableDataWithState = COLOC_QTL_TABLE_DATA.map(d => ({
-      ...d,
-      isShowingRegional: regionals.some(
-        r =>
-          r.study === d.study &&
-          r.phenotype === d.phenotype &&
-          r.bioFeature === d.bioFeature &&
-          r.chrom === d.chrom &&
-          r.pos === d.pos &&
-          r.ref === d.ref &&
-          r.alt === d.alt
-      ),
-    }));
+    const colocQtlTableDataWithState = COLOC_QTL_TABLE_DATA;
     const colocGWASTableDataWithState = COLOC_GWAS_TABLE_DATA.map(d => ({
       ...d,
       ...STUDY_INFOS[d.study],
-      isShowingRegional: regionals.some(
-        r =>
-          r.study === d.study &&
-          r.phenotype === d.phenotype &&
-          r.bioFeature === d.bioFeature &&
-          r.chrom === d.chrom &&
-          r.pos === d.pos &&
-          r.ref === d.ref &&
-          r.alt === d.alt
-      ),
     }));
     // const { match } = this.props;
     // const { studyId, indexVariantId } = match.params;
@@ -282,69 +236,6 @@ class LocusTraitPage extends React.Component {
         ) : null}
 
         <SectionHeading
-          heading={`Regional Plots`}
-          subheading={
-            <React.Fragment>
-              Where is the signal for molecular traits and GWAS studies
-              colocalising with <strong>{traitAuthorYear(STUDY_INFO)}</strong>?
-            </React.Fragment>
-          }
-        />
-        <PlotContainer
-          center={
-            <Typography align="center">
-              The plot for <strong>{traitAuthorYear(STUDY_INFO)}</strong> is
-              always shown. Where possible, credible sets are shown in blue.
-              <br />
-              You can add or remove others in the QTL and GWAS tables above.
-            </Typography>
-          }
-        >
-          <Regional
-            data={SUMSTATS_PAGE_STUDY}
-            title={traitAuthorYear(STUDY_INFO)}
-            start={START}
-            end={END}
-          />
-          {colocGWASTableDataWithState
-            .filter(d => d.isShowingRegional)
-            .sort(logH4H3Comparator)
-            .reverse()
-            .map(d => (
-              <Regional
-                key={`${d.study}`}
-                data={combineSumStatsWithCredSets({
-                  ...d,
-                  chromosome: CHROMOSOME,
-                })}
-                title={traitAuthorYear(STUDY_INFOS[d.study])}
-                start={START}
-                end={END}
-              />
-            ))}
-          {colocQtlTableDataWithState
-            .filter(d => d.isShowingRegional)
-            .sort(logH4H3Comparator)
-            .reverse()
-            .map(d => (
-              <Regional
-                key={`${d.phenotype}-${d.bioFeature}`}
-                data={combineSumStatsWithCredSets({
-                  ...d,
-                  chromosome: CHROMOSOME,
-                })}
-                title={`${d.study}: ${d.phenotypeSymbol} in ${d.bioFeature}`}
-                start={START}
-                end={END}
-              />
-            ))}
-          <GeneTrack
-            data={flatExonsToPairedExons(GENES)}
-            start={START}
-            end={END}
-          />
-        </PlotContainer>
-        <SectionHeading
           heading={`Credible Set Overlap`}
           subheading={`Which variants at this locus are most likely causal?`}
         />
@@ -352,8 +243,9 @@ class LocusTraitPage extends React.Component {
           center={
             <Typography>
               Showing credible sets for{' '}
-              <strong>{traitAuthorYear(STUDY_INFO)}</strong> and QTLs in
-              colocalisation.
+              <strong>{traitAuthorYear(STUDY_INFO)}</strong> and GWAS
+              studies/QTLs in colocalisation. Expand the section to see the
+              underlying regional plot.
             </Typography>
           }
         >
@@ -467,6 +359,21 @@ class LocusTraitPage extends React.Component {
               />
             ) : null;
           })}
+
+        <Typography style={{ paddingTop: '10px' }}>
+          <strong>Genes</strong>
+        </Typography>
+        <PlotContainer>
+          <PlotContainerSection>
+            <div style={{ paddingRight: '32px' }}>
+              <GeneTrack
+                data={flatExonsToPairedExons(GENES)}
+                start={START}
+                end={END}
+              />
+            </div>
+          </PlotContainerSection>
+        </PlotContainer>
 
         <SectionHeading
           heading={`Genes`}

--- a/src/pages/LocusTraitPage.js
+++ b/src/pages/LocusTraitPage.js
@@ -370,109 +370,104 @@ class LocusTraitPage extends React.Component {
               <FormControlLabel value="all" control={<Radio />} label="all" />
             </RadioGroup>
           </PlotContainerSection>
-
-          <PlotContainerSection>
-            <CredibleSetWithRegional
-              credibleSetProps={{
-                label: traitAuthorYear(STUDY_INFO),
-                start: START,
-                end: END,
-                data: pageCredibleSet,
-              }}
-              regionalProps={{
-                data: SUMSTATS_PAGE_STUDY,
-                title: traitAuthorYear(STUDY_INFO),
-                start: START,
-                end: END,
-              }}
-            />
-          </PlotContainerSection>
-          <PlotContainerSection>
-            <Typography style={{ padding: '5px 10px' }}>
-              <strong>GWAS</strong>
-            </Typography>
-            {colocGWASTableDataWithState
-              .sort(logH4H3Comparator)
-              .reverse()
-              .map(d => {
-                const { study, chrom, pos, ref, alt } = d;
-                const key = `${study}__null__null__${chrom}__${pos}__${ref}__${alt}`;
-                return Object.keys(CREDSETS_TABLE_DATA).indexOf(key) >= 0 &&
-                  CREDSETS_TABLE_DATA[key].length > 0 ? (
-                  <CredibleSetWithRegional
-                    key={key}
-                    credibleSetProps={{
-                      label: traitAuthorYear(STUDY_INFOS[d.study]),
-                      start: START,
-                      end: END,
-                      data:
-                        this.state.credSet95Value === 'all'
-                          ? CREDSETS_TABLE_DATA[key]
-                          : CREDSETS_TABLE_DATA[key].filter(
-                              d => d.is95CredibleSet
-                            ),
-                    }}
-                    regionalProps={{
-                      data: combineSumStatsWithCredSets({
-                        ...d,
-                        chromosome: CHROMOSOME,
-                      }),
-                      title: traitAuthorYear(STUDY_INFO),
-                      start: START,
-                      end: END,
-                    }}
-                  />
-                ) : null;
-              })}
-          </PlotContainerSection>
-          <PlotContainerSection>
-            <Typography style={{ padding: '5px 10px' }}>
-              <strong>QTLs</strong>
-            </Typography>
-            {colocQtlTableDataWithState
-              .sort(logH4H3Comparator)
-              .reverse()
-              .map(d => {
-                const {
-                  study,
-                  phenotype,
-                  phenotypeSymbol,
-                  bioFeature,
-                  chrom,
-                  pos,
-                  ref,
-                  alt,
-                } = d;
-                const key = `${study}__${phenotype}__${bioFeature}__${chrom}__${pos}__${ref}__${alt}`;
-                return Object.keys(CREDSETS_TABLE_DATA).indexOf(key) >= 0 &&
-                  CREDSETS_TABLE_DATA[key].length > 0 ? (
-                  <CredibleSetWithRegional
-                    key={key}
-                    credibleSetProps={{
-                      label: `${study}: ${phenotypeSymbol} in ${bioFeature}`,
-                      start: START,
-                      end: END,
-                      data:
-                        this.state.credSet95Value === 'all'
-                          ? CREDSETS_TABLE_DATA[key]
-                          : CREDSETS_TABLE_DATA[key].filter(
-                              d => d.is95CredibleSet
-                            ),
-                    }}
-                    regionalProps={{
-                      data: combineSumStatsWithCredSets({
-                        ...d,
-                        chromosome: CHROMOSOME,
-                      }),
-                      title: traitAuthorYear(STUDY_INFO),
-                      start: START,
-                      end: END,
-                    }}
-                  />
-                ) : null;
-              })}
-          </PlotContainerSection>
         </PlotContainer>
+
+        <CredibleSetWithRegional
+          credibleSetProps={{
+            label: traitAuthorYear(STUDY_INFO),
+            start: START,
+            end: END,
+            data: pageCredibleSet,
+          }}
+          regionalProps={{
+            data: SUMSTATS_PAGE_STUDY,
+            title: null,
+            start: START,
+            end: END,
+          }}
+        />
+
+        <Typography style={{ paddingTop: '10px' }}>
+          <strong>GWAS</strong>
+        </Typography>
+
+        {colocGWASTableDataWithState
+          .sort(logH4H3Comparator)
+          .reverse()
+          .map(d => {
+            const { study, chrom, pos, ref, alt } = d;
+            const key = `${study}__null__null__${chrom}__${pos}__${ref}__${alt}`;
+            return Object.keys(CREDSETS_TABLE_DATA).indexOf(key) >= 0 &&
+              CREDSETS_TABLE_DATA[key].length > 0 ? (
+              <CredibleSetWithRegional
+                key={key}
+                credibleSetProps={{
+                  label: traitAuthorYear(STUDY_INFOS[d.study]),
+                  start: START,
+                  end: END,
+                  data:
+                    this.state.credSet95Value === 'all'
+                      ? CREDSETS_TABLE_DATA[key]
+                      : CREDSETS_TABLE_DATA[key].filter(d => d.is95CredibleSet),
+                }}
+                regionalProps={{
+                  data: combineSumStatsWithCredSets({
+                    ...d,
+                    chromosome: CHROMOSOME,
+                  }),
+                  title: null,
+                  start: START,
+                  end: END,
+                }}
+              />
+            ) : null;
+          })}
+
+        <Typography style={{ paddingTop: '10px' }}>
+          <strong>QTLs</strong>
+        </Typography>
+
+        {colocQtlTableDataWithState
+          .sort(logH4H3Comparator)
+          .reverse()
+          .map(d => {
+            const {
+              study,
+              phenotype,
+              phenotypeSymbol,
+              bioFeature,
+              chrom,
+              pos,
+              ref,
+              alt,
+            } = d;
+            const key = `${study}__${phenotype}__${bioFeature}__${chrom}__${pos}__${ref}__${alt}`;
+            return Object.keys(CREDSETS_TABLE_DATA).indexOf(key) >= 0 &&
+              CREDSETS_TABLE_DATA[key].length > 0 ? (
+              <CredibleSetWithRegional
+                key={key}
+                credibleSetProps={{
+                  label: `${study}: ${phenotypeSymbol} in ${bioFeature}`,
+                  start: START,
+                  end: END,
+                  data:
+                    this.state.credSet95Value === 'all'
+                      ? CREDSETS_TABLE_DATA[key]
+                      : CREDSETS_TABLE_DATA[key].filter(d => d.is95CredibleSet),
+                }}
+                regionalProps={{
+                  data: combineSumStatsWithCredSets({
+                    ...d,
+                    chromosome: CHROMOSOME,
+                  }),
+                  title: null,
+                  start: START,
+                  end: END,
+                }}
+              />
+            ) : null;
+          })}
+
         <SectionHeading
           heading={`Genes`}
           subheading={`Which genes are functionally implicated by variants at this locus?`}

--- a/src/pages/LocusTraitPage.js
+++ b/src/pages/LocusTraitPage.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+
 import Typography from '@material-ui/core/Typography';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
@@ -19,6 +20,7 @@ import ColocQTLTable from '../components/ColocQTLTable';
 import ColocQTLGeneTissueTable from '../components/ColocQTLGeneTissueTable';
 import ColocGWASTable from '../components/ColocGWASTable';
 import ColocGWASHeatmapTable from '../components/ColocGWASHeatmapTable';
+import CredibleSetWithRegional from '../components/CredibleSetWithRegional';
 
 import STUDY_INFOS from '../mock-data/study-info.json';
 
@@ -368,12 +370,21 @@ class LocusTraitPage extends React.Component {
               <FormControlLabel value="all" control={<Radio />} label="all" />
             </RadioGroup>
           </PlotContainerSection>
+
           <PlotContainerSection>
-            <CredibleSet
-              label={traitAuthorYear(STUDY_INFO)}
-              start={START}
-              end={END}
-              data={pageCredibleSet}
+            <CredibleSetWithRegional
+              credibleSetProps={{
+                label: traitAuthorYear(STUDY_INFO),
+                start: START,
+                end: END,
+                data: pageCredibleSet,
+              }}
+              regionalProps={{
+                data: SUMSTATS_PAGE_STUDY,
+                title: traitAuthorYear(STUDY_INFO),
+                start: START,
+                end: END,
+              }}
             />
           </PlotContainerSection>
           <PlotContainerSection>
@@ -388,18 +399,28 @@ class LocusTraitPage extends React.Component {
                 const key = `${study}__null__null__${chrom}__${pos}__${ref}__${alt}`;
                 return Object.keys(CREDSETS_TABLE_DATA).indexOf(key) >= 0 &&
                   CREDSETS_TABLE_DATA[key].length > 0 ? (
-                  <CredibleSet
+                  <CredibleSetWithRegional
                     key={key}
-                    label={traitAuthorYear(STUDY_INFOS[d.study])}
-                    start={START}
-                    end={END}
-                    data={
-                      this.state.credSet95Value === 'all'
-                        ? CREDSETS_TABLE_DATA[key]
-                        : CREDSETS_TABLE_DATA[key].filter(
-                            d => d.is95CredibleSet
-                          )
-                    }
+                    credibleSetProps={{
+                      label: traitAuthorYear(STUDY_INFOS[d.study]),
+                      start: START,
+                      end: END,
+                      data:
+                        this.state.credSet95Value === 'all'
+                          ? CREDSETS_TABLE_DATA[key]
+                          : CREDSETS_TABLE_DATA[key].filter(
+                              d => d.is95CredibleSet
+                            ),
+                    }}
+                    regionalProps={{
+                      data: combineSumStatsWithCredSets({
+                        ...d,
+                        chromosome: CHROMOSOME,
+                      }),
+                      title: traitAuthorYear(STUDY_INFO),
+                      start: START,
+                      end: END,
+                    }}
                   />
                 ) : null;
               })}
@@ -425,18 +446,28 @@ class LocusTraitPage extends React.Component {
                 const key = `${study}__${phenotype}__${bioFeature}__${chrom}__${pos}__${ref}__${alt}`;
                 return Object.keys(CREDSETS_TABLE_DATA).indexOf(key) >= 0 &&
                   CREDSETS_TABLE_DATA[key].length > 0 ? (
-                  <CredibleSet
+                  <CredibleSetWithRegional
                     key={key}
-                    label={`${study}: ${phenotypeSymbol} in ${bioFeature}`}
-                    start={START}
-                    end={END}
-                    data={
-                      this.state.credSet95Value === 'all'
-                        ? CREDSETS_TABLE_DATA[key]
-                        : CREDSETS_TABLE_DATA[key].filter(
-                            d => d.is95CredibleSet
-                          )
-                    }
+                    credibleSetProps={{
+                      label: `${study}: ${phenotypeSymbol} in ${bioFeature}`,
+                      start: START,
+                      end: END,
+                      data:
+                        this.state.credSet95Value === 'all'
+                          ? CREDSETS_TABLE_DATA[key]
+                          : CREDSETS_TABLE_DATA[key].filter(
+                              d => d.is95CredibleSet
+                            ),
+                    }}
+                    regionalProps={{
+                      data: combineSumStatsWithCredSets({
+                        ...d,
+                        chromosome: CHROMOSOME,
+                      }),
+                      title: traitAuthorYear(STUDY_INFO),
+                      start: START,
+                      end: END,
+                    }}
                   />
                 ) : null;
               })}

--- a/src/pages/LocusTraitPage.js
+++ b/src/pages/LocusTraitPage.js
@@ -132,8 +132,8 @@ class LocusTraitPage extends React.Component {
     qtlTabsValue: 'heatmap',
     gwasTabsValue: 'heatmap',
     credSet95Value: 'all',
-    logH4H3SliderValue: 0,
-    h4SliderValue: 0,
+    logH4H3SliderValue: Math.log(2), // ln(2) equivalent to H4 being double H3; suggested by Ed
+    h4SliderValue: 0.2, // 20% default; suggested by Ed
   };
   handleQtlTabsChange = (_, qtlTabsValue) => {
     this.setState({ qtlTabsValue });

--- a/src/pages/LocusTraitPage.js
+++ b/src/pages/LocusTraitPage.js
@@ -348,7 +348,7 @@ class LocusTraitPage extends React.Component {
           .sort(logH4H3Comparator)
           .reverse()
           .map(d => {
-            const { study, chrom, pos, ref, alt } = d;
+            const { study, chrom, pos, ref, alt, h4, logH4H3 } = d;
             const key = `${study}__null__null__${chrom}__${pos}__${ref}__${alt}`;
             return Object.keys(CREDSETS_TABLE_DATA).indexOf(key) >= 0 &&
               CREDSETS_TABLE_DATA[key].length > 0 ? (
@@ -358,6 +358,8 @@ class LocusTraitPage extends React.Component {
                   label: traitAuthorYear(STUDY_INFOS[d.study]),
                   start: START,
                   end: END,
+                  h4,
+                  logH4H3,
                   data:
                     this.state.credSet95Value === 'all'
                       ? CREDSETS_TABLE_DATA[key]
@@ -399,6 +401,8 @@ class LocusTraitPage extends React.Component {
               pos,
               ref,
               alt,
+              h4,
+              logH4H3,
             } = d;
             const key = `${study}__${phenotype}__${bioFeature}__${chrom}__${pos}__${ref}__${alt}`;
             return Object.keys(CREDSETS_TABLE_DATA).indexOf(key) >= 0 &&
@@ -409,6 +413,8 @@ class LocusTraitPage extends React.Component {
                   label: `${study}: ${phenotypeSymbol} in ${bioFeature}`,
                   start: START,
                   end: END,
+                  h4,
+                  logH4H3,
                   data:
                     this.state.credSet95Value === 'all'
                       ? CREDSETS_TABLE_DATA[key]

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,6 +132,16 @@
     "@babel/runtime" "^7.2.0"
     recompose "0.28.0 - 0.30.0"
 
+"@material-ui/lab@^3.0.0-alpha.30":
+  version "3.0.0-alpha.30"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-3.0.0-alpha.30.tgz#c6c64d0ff2b28410a09e4009f3677499461f3df8"
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    "@material-ui/utils" "^3.0.0-alpha.2"
+    classnames "^2.2.5"
+    keycode "^2.1.9"
+    prop-types "^15.6.0"
+
 "@material-ui/system@^3.0.0-alpha.0":
   version "3.0.0-alpha.2"
   resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-3.0.0-alpha.2.tgz#096e80c8bb0f70aea435b9e38ea7749ee77b4e46"
@@ -5094,6 +5104,10 @@ jsx-ast-utils@^2.0.0:
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
     array-includes "^3.0.3"
+
+keycode@^2.1.9:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
 
 killable@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6092,9 +6092,9 @@ ot-charts@^0.0.41:
   dependencies:
     lodash.sortby "^4.7.0"
 
-ot-ui@^0.0.82:
-  version "0.0.82"
-  resolved "https://registry.yarnpkg.com/ot-ui/-/ot-ui-0.0.82.tgz#a2c8327e5da6d9a7f56f2efeef8cf65c25447a58"
+ot-ui@^0.0.84:
+  version "0.0.84"
+  resolved "https://registry.yarnpkg.com/ot-ui/-/ot-ui-0.0.84.tgz#51c0c15d9d99220132427d76c757e84c4a0128e4"
 
 p-finally@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6086,9 +6086,9 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-ot-charts@^0.0.41:
-  version "0.0.41"
-  resolved "https://registry.yarnpkg.com/ot-charts/-/ot-charts-0.0.41.tgz#25b2248f6b8f93a3e73ada361c9b072c47761fb1"
+ot-charts@^0.0.43:
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/ot-charts/-/ot-charts-0.0.43.tgz#2d3642729c71162e760d61b4d3992edfdd83c3cb"
   dependencies:
     lodash.sortby "^4.7.0"
 


### PR DESCRIPTION
This PR implements the main changes from last week's review of the study-locus page. Notably:
* regional plots are now in expansion panels under each credible set
* regional plots cannot be individually toggled
* adds sliders for `h4` and `log(h4/h3)` on credible sets (defaults of `0.2` and `ln2` respectively; discussed with Ed)