### PR TITLE
Improve environment variable handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "start": "react-app-rewired start",
-    "build": "REACT_APP_REVISION=\"$(git rev-parse --short HEAD)\" react-app-rewired build",
+    "build": "REACT_APP_GIT_REVISION=\"$(git rev-parse --short HEAD)\" react-app-rewired build",
     "test": "react-app-rewired test --env=jsdom",
     "test:coverage": "yarn test --coverage",
     "eject": "react-scripts eject",

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,0 +1,15 @@
+import pkg from '../package.json';
+
+const defaults = {
+  REACT_APP_GRAPHQL_API_URL: 'https://genetics-api.opentargets.io',
+  REACT_APP_PLATFORM_URL: 'https://www.targetvalidation.org',
+  REACT_APP_GIT_REVISION: '2222ccc',
+};
+
+const envVarOrDefault = envVarName =>
+  process.env[envVarName] ? process.env[envVarName] : defaults[envVarName];
+
+export const packageVersion = pkg.version;
+export const graphqlApiUrl = envVarOrDefault('REACT_APP_GRAPHQL_API_URL');
+export const platformUrl = envVarOrDefault('REACT_APP_PLATFORM_URL');
+export const gitRevision = envVarOrDefault('REACT_APP_GIT_REVISION');

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,20 +1,12 @@
-import pkg from '../package.json';
+import { platformUrl, gitRevision, packageVersion } from './configuration';
 
 export const pvalThreshold = 4.94e-322;
 
 export const externalLinks = {
   about: [
     {
-      label: `Version ${pkg.version} (${
-        process.env.REACT_APP_REVISION
-          ? process.env.REACT_APP_REVISION
-          : '2222ccc'
-      })`,
-      url: `https://github.com/opentargets/genetics-app/commit/${
-        process.env.REACT_APP_REVISION
-          ? process.env.REACT_APP_REVISION
-          : '2222ccc'
-      }`,
+      label: `Version ${packageVersion} (${gitRevision})`,
+      url: `https://github.com/opentargets/genetics-app/commit/${gitRevision}`,
     },
     {
       label: 'Github codebase',
@@ -26,7 +18,7 @@ export const externalLinks = {
     },
     {
       label: 'Terms of use',
-      url: 'http://www.targetvalidation.org/terms-of-use',
+      url: `${platformUrl}/terms-of-use`,
     },
   ],
   network: [

--- a/src/index.js
+++ b/src/index.js
@@ -11,15 +11,11 @@ import { HttpLink } from 'apollo-link-http';
 
 import App from './App';
 import { unregister } from './registerServiceWorker';
-
-const apiUrlDefault = 'https://genetics-api.opentargets.io';
-const apiUrl = process.env.REACT_APP_GRAPHQL_API_URL
-  ? process.env.REACT_APP_GRAPHQL_API_URL
-  : apiUrlDefault;
+import { graphqlApiUrl } from './configuration';
 
 const client = new ApolloClient({
   link: new HttpLink({
-    uri: `${apiUrl}/graphql`,
+    uri: `${graphqlApiUrl}/graphql`,
   }),
   cache: new InMemoryCache(),
 });

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -24,6 +24,7 @@ import BasePage from './BasePage';
 import LocusLink from '../components/LocusLink';
 import AssociatedStudiesTable from '../components/AssociatedStudiesTable';
 import GENE_PAGE_QUERY from '../queries/GenePageQuery.gql';
+import { platformUrl } from '../configuration';
 
 function hasGeneData(data) {
   return data && data.geneInfo;
@@ -231,7 +232,7 @@ class GenePage extends React.Component {
                         <Grid item className={classes.geneInfoItem}>
                           <a
                             className={classes.platformLink}
-                            href={`https://www.targetvalidation.org/target/${geneId}`}
+                            href={`${platformUrl}/target/${geneId}`}
                             target="_blank"
                           >
                             <OverviewIcon className={classes.iconLink} />
@@ -241,7 +242,7 @@ class GenePage extends React.Component {
                         <Grid item className={classes.geneInfoItem}>
                           <a
                             className={classes.platformLink}
-                            href={`https://www.targetvalidation.org/target/${geneId}?view=sec:known_drug`}
+                            href={`${platformUrl}/target/${geneId}?view=sec:known_drug`}
                             target="_blank"
                           >
                             <DrugsIcon className={classes.iconLink} />
@@ -251,7 +252,7 @@ class GenePage extends React.Component {
                         <Grid item className={classes.geneInfoItem}>
                           <a
                             className={classes.platformLink}
-                            href={`https://www.targetvalidation.org/target/${geneId}?view=sec:mouse_phenotypes`}
+                            href={`${platformUrl}/target/${geneId}?view=sec:mouse_phenotypes`}
                             target="_blank"
                           >
                             <MouseIcon className={classes.iconLink} />
@@ -263,7 +264,7 @@ class GenePage extends React.Component {
                         <Grid item className={classes.geneInfoItem}>
                           <a
                             className={classes.platformLink}
-                            href={`https://www.targetvalidation.org/target/${geneId}?view=sec:affected_pathway`}
+                            href={`${platformUrl}/target/${geneId}?view=sec:affected_pathway`}
                             target="_blank"
                           >
                             <PathwaysIcon className={classes.iconLink} />
@@ -273,7 +274,7 @@ class GenePage extends React.Component {
                         <Grid item className={classes.geneInfoItem}>
                           <a
                             className={classes.platformLink}
-                            href={`https://www.targetvalidation.org/target/${geneId}?view=sec:expression`}
+                            href={`${platformUrl}/target/${geneId}?view=sec:expression`}
                             target="_blank"
                           >
                             <ExpressionIcon className={classes.iconLink} />


### PR DESCRIPTION
This PR creates a configuration file with defaults for accepted environment variables. We may want to add more in the future.

Anyone could now also use `.env` to manage variations, such as `.env.local`, `.env.production`. The public site has some variability (API by branch, for example), which is currently managed within the `netlify.toml` file.

Motivation: see https://github.com/opentargets/genetics/issues/338.