### PR TITLE
Lf updates 408

### DIFF
--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -32,30 +32,31 @@ const getDownloadColumns = () => {
     { id: 'oddsRatio', label: 'Odds Ratio' },
     { id: 'oddsRatioCILower', label: 'Odds Ratio CI Lower' },
     { id: 'oddsRatioCIUpper', label: 'Odds Ratio CI Upper' },
+    { id: 'yProbaModel', label: 'L2G Pipeline Score' },
   ];
 };
 
 const getDownloadRows = rows => {
-  // return rows.map(row => ({
-  //   studyId: row.study.studyId,
-  //   studyTrait: row.study.traitReported,
-  //   studyPmid: row.study.pmid,
-  //   studyAuthor: row.study.pubAuthor,
-  //   studyDate: row.study.pubDate,
-  //   nInitial: row.study.nInitial,
-  //   nReplication: row.study.nReplication,
-  //   nCases: row.study.nCases,
-  //   indexVariantId: row.indexVariant.id,
-  //   indexVariantRsId: row.indexVariant.rsId,
-  //   pval: row.pval,
-  //   beta: row.beta,
-  //   betaCILower: row.betaCILower,
-  //   betaCIUpper: row.betaCIUpper,
-  //   oddsRatio: row.oddsRatio,
-  //   oddsRatioCILower: row.oddsRatioCILower,
-  //   oddsRatioCIUpper: row.oddsRatioCIUpper,
-  // }));
-  return [];
+  return rows.map(row => ({
+    studyId: row.study.studyId,
+    studyTrait: row.study.traitReported,
+    studyPmid: row.study.pmid,
+    studyAuthor: row.study.pubAuthor,
+    studyDate: row.study.pubDate,
+    nInitial: row.study.nInitial,
+    nReplication: row.study.nReplication,
+    nCases: row.study.nCases,
+    indexVariantId: row.variant.id,
+    indexVariantRsId: row.variant.rsId,
+    pval: row.pval,
+    beta: row.beta.betaCI,
+    betaCILower: row.beta.betaCILower,
+    betaCIUpper: row.beta.betaCIUpper,
+    oddsRatio: row.odds.oddsCI,
+    oddsRatioCILower: row.odds.oddsCILower,
+    oddsRatioCIUpper: row.odds.oddsCIUpper,
+    yProbaModel: row.yProbaModel,
+  }));
 };
 
 const tableColumns = ({

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -222,20 +222,32 @@ const tableColumns = ({
   {
     id: 'locusView',
     label: 'View',
-    renderCell: rowData => (
-      <StudyLocusLink
-        hasSumsStats={rowData.study.hasSumsStats}
-        indexVariantId={rowData.variant.id}
-        studyId={rowData.study.studyId}
-        label={
-          <div>
-            Gene prioritisation
-            <br />
-            <small>(L2G pipeline)</small>
-          </div>
-        }
-      />
-    ),
+    renderCell: rowData => {
+      return (
+        <StudyLocusLink
+          hasSumsStats={rowData.study.hasSumsStats}
+          indexVariantId={rowData.variant.id}
+          studyId={rowData.study.studyId}
+          label={
+            <div>
+              Gene prioritisation
+              <br />
+              <small>(L2G pipeline)</small>
+            </div>
+          }
+        />
+      );
+      // Alternative link styling option:
+      // return (
+      //   <Link
+      //     to={`/study-locus/${rowData.study.studyId}/${rowData.variant.id}`}
+      //   >
+      //     Gene prioritisation
+      //     <br />
+      //     <small>(L2G pipeline)</small>
+      //   </Link>
+      // );
+    },
   },
 ];
 

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -226,25 +226,9 @@ const tableColumns = ({
           hasSumsStats={rowData.study.hasSumsStats}
           indexVariantId={rowData.variant.id}
           studyId={rowData.study.studyId}
-          label={
-            <div>
-              Gene prioritisation
-              <br />
-              <small>(L2G pipeline)</small>
-            </div>
-          }
+          label="Gene prioritisation"
         />
       );
-      // Alternative link styling option:
-      // return (
-      //   <Link
-      //     to={`/study-locus/${rowData.study.studyId}/${rowData.variant.id}`}
-      //   >
-      //     Gene prioritisation
-      //     <br />
-      //     <small>(L2G pipeline)</small>
-      //   </Link>
-      // );
     },
   },
 ];

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -11,7 +11,6 @@ import {
 import { pvalThreshold } from '../constants';
 import LocusLink from './LocusLink';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
-import PmidOrBiobankLink from './PmidOrBiobankLink';
 import generateComparator from '../utils/generateComparator';
 
 const getDownloadColumns = () => {
@@ -95,17 +94,6 @@ const tableColumns = ({
     ),
   },
   {
-    id: 'study.pmid',
-    label: 'PMID',
-    comparator: generateComparator(d => d.study.pmid),
-    renderCell: rowData => (
-      <PmidOrBiobankLink
-        studyId={rowData.study.studyId}
-        pmid={rowData.study.pmid}
-      />
-    ),
-  },
-  {
     id: 'study.pubAuthor',
     label: 'Author (Year)',
     comparator: generateComparator(d => d.study.pubAuthor),
@@ -131,13 +119,6 @@ const tableColumns = ({
       rowData.study.nInitial ? commaSeparate(rowData.study.nInitial) : '',
   },
   {
-    id: 'study.nCases',
-    label: 'N Cases',
-    comparator: generateComparator(d => d.study.nCases),
-    renderCell: rowData =>
-      rowData.study.nCases ? commaSeparate(rowData.study.nCases) : '',
-  },
-  {
     id: 'indexVariant.id',
     label: 'Lead Variant',
     comparator: generateComparator(d => d.indexVariant.id),
@@ -146,12 +127,6 @@ const tableColumns = ({
         {rowData.indexVariant.id}
       </Link>
     ),
-  },
-  {
-    id: 'indexVariant.rsId',
-    label: 'Lead Variant rsID',
-    comparator: generateComparator(d => d.indexVariant.rsId),
-    renderCell: rowData => rowData.indexVariant.rsId,
   },
   {
     id: 'pval',

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -36,25 +36,26 @@ const getDownloadColumns = () => {
 };
 
 const getDownloadRows = rows => {
-  return rows.map(row => ({
-    studyId: row.study.studyId,
-    studyTrait: row.study.traitReported,
-    studyPmid: row.study.pmid,
-    studyAuthor: row.study.pubAuthor,
-    studyDate: row.study.pubDate,
-    nInitial: row.study.nInitial,
-    nReplication: row.study.nReplication,
-    nCases: row.study.nCases,
-    indexVariantId: row.indexVariant.id,
-    indexVariantRsId: row.indexVariant.rsId,
-    pval: row.pval,
-    beta: row.beta,
-    betaCILower: row.betaCILower,
-    betaCIUpper: row.betaCIUpper,
-    oddsRatio: row.oddsRatio,
-    oddsRatioCILower: row.oddsRatioCILower,
-    oddsRatioCIUpper: row.oddsRatioCIUpper,
-  }));
+  // return rows.map(row => ({
+  //   studyId: row.study.studyId,
+  //   studyTrait: row.study.traitReported,
+  //   studyPmid: row.study.pmid,
+  //   studyAuthor: row.study.pubAuthor,
+  //   studyDate: row.study.pubDate,
+  //   nInitial: row.study.nInitial,
+  //   nReplication: row.study.nReplication,
+  //   nCases: row.study.nCases,
+  //   indexVariantId: row.indexVariant.id,
+  //   indexVariantRsId: row.indexVariant.rsId,
+  //   pval: row.pval,
+  //   beta: row.beta,
+  //   betaCILower: row.betaCILower,
+  //   betaCIUpper: row.betaCIUpper,
+  //   oddsRatio: row.oddsRatio,
+  //   oddsRatioCILower: row.oddsRatioCILower,
+  //   oddsRatioCIUpper: row.oddsRatioCIUpper,
+  // }));
+  return [];
 };
 
 const tableColumns = ({
@@ -119,13 +120,11 @@ const tableColumns = ({
       rowData.study.nInitial ? commaSeparate(rowData.study.nInitial) : '',
   },
   {
-    id: 'indexVariant.id',
+    id: 'variant.id',
     label: 'Lead Variant',
-    comparator: generateComparator(d => d.indexVariant.id),
+    comparator: generateComparator(d => d.variant.id),
     renderCell: rowData => (
-      <Link to={`/variant/${rowData.indexVariant.id}`}>
-        {rowData.indexVariant.id}
-      </Link>
+      <Link to={`/variant/${rowData.variant.id}`}>{rowData.variant.id}</Link>
     ),
   },
   {
@@ -137,7 +136,7 @@ const tableColumns = ({
         : significantFigures(rowData.pval),
   },
   {
-    id: 'beta',
+    id: 'beta.betaCI',
     label: 'Beta',
     tooltip: (
       <React.Fragment>
@@ -152,14 +151,14 @@ const tableColumns = ({
       </React.Fragment>
     ),
     renderCell: rowData =>
-      rowData.beta ? significantFigures(rowData.beta) : null,
+      rowData.beta.betaCI ? significantFigures(rowData.beta.betaCI) : null,
   },
   {
-    id: 'oddsRatio',
+    id: 'odds.oddsCI',
     label: 'Odds Ratio',
     tooltip: 'Odds ratio with respect to the ALT allele',
     renderCell: rowData =>
-      rowData.oddsRatio ? significantFigures(rowData.oddsRatio) : null,
+      rowData.odds.oddsCI ? significantFigures(rowData.odds.oddsCI) : null,
   },
   {
     id: 'ci',
@@ -167,15 +166,22 @@ const tableColumns = ({
     tooltip:
       '95% confidence interval for the effect estimate. CIs are calculated approximately using the reported p-value.',
     renderCell: rowData =>
-      rowData.beta
-        ? `(${significantFigures(rowData.betaCILower)}, ${significantFigures(
-            rowData.betaCIUpper
-          )})`
-        : rowData.oddsRatio
+      rowData.beta.betaCI
+        ? `(${significantFigures(
+            rowData.beta.betaCILower
+          )}, ${significantFigures(rowData.beta.betaCIUpper)})`
+        : rowData.odds.oddsCI
           ? `(${significantFigures(
-              rowData.oddsRatioCILower
-            )}, ${significantFigures(rowData.oddsRatioCIUpper)})`
+              rowData.odds.oddsCILower
+            )}, ${significantFigures(rowData.odds.oddsCIUpper)})`
           : null,
+  },
+  {
+    id: 'yProbaModel',
+    label: 'L2G pipeline score',
+    tooltip: '',
+    renderCell: rowData =>
+      rowData.yProbaModel ? significantFigures(rowData.yProbaModel) : null,
   },
   {
     id: 'locusView',

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -124,9 +124,7 @@ const tableColumns = ({
     renderCell: rowData => {
       // Some studies don't have a pmid so need to avoid dead links
       const url = rowData.study.pmid
-        ? `"http://europepmc.org/article/MED/${
-            rowData.study.pmid.split(':')[1]
-          }"`
+        ? `http://europepmc.org/article/MED/${rowData.study.pmid.split(':')[1]}`
         : null;
       const pub = `${rowData.study.pubAuthor} (${new Date(
         rowData.study.pubDate

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -85,7 +85,18 @@ const tableColumns = ({
     id: 'study.traitReported',
     label: 'Trait',
     comparator: generateComparator(d => d.study.traitReported),
-    renderCell: rowData => rowData.study.traitReported,
+    renderCell: rowData => {
+      // truncate long trait names for display
+      return rowData.study.traitReported &&
+        rowData.study.traitReported.length > 100 ? (
+        <span title={rowData.study.traitReported}>
+          {rowData.study.traitReported.substring(0, 100)}
+          &hellip;
+        </span>
+      ) : (
+        rowData.study.traitReported
+      );
+    },
     renderFilter: () => (
       <Autocomplete
         options={traitFilterOptions}

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -286,8 +286,8 @@ const AssociatedStudiesTable = ({
         authorFilterHandler,
       })}
       data={data}
-      sortBy="pval"
-      order="asc"
+      sortBy="yProbaModel"
+      order="desc"
       reportTableDownloadEvent={format => {
         reportAnalyticsEvent({
           category: 'table',

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -9,7 +9,7 @@ import {
 } from 'ot-ui';
 
 import { pvalThreshold } from '../constants';
-import LocusLink from './LocusLink';
+import StudyLocusLink from './StudyLocusLink';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
 import generateComparator from '../utils/generateComparator';
 
@@ -211,14 +211,18 @@ const tableColumns = ({
     id: 'locusView',
     label: 'View',
     renderCell: rowData => (
-      <LocusLink
-        chromosome={chromosome}
-        position={position}
-        selectedGenes={[geneId]}
-        selectedStudies={[rowData.study.studyId]}
-      >
-        Locus
-      </LocusLink>
+      <StudyLocusLink
+        hasSumsStats={rowData.study.hasSumsStats}
+        indexVariantId={rowData.variant.id}
+        studyId={rowData.study.studyId}
+        label={
+          <div>
+            Gene prioritisation
+            <br />
+            <small>(L2G pipeline)</small>
+          </div>
+        }
+      />
     ),
   },
 ];

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import {
   DataDownloader,
   OtTableRF,
@@ -159,7 +159,7 @@ const tableColumns = ({
     id: 'beta.betaCI',
     label: 'Beta',
     tooltip: (
-      <React.Fragment>
+      <Fragment>
         Beta with respect to the ALT allele.
         <Link
           external
@@ -168,7 +168,7 @@ const tableColumns = ({
         >
           See FAQ.
         </Link>
-      </React.Fragment>
+      </Fragment>
     ),
     renderCell: rowData =>
       rowData.beta.betaCI ? significantFigures(rowData.beta.betaCI) : null,
@@ -242,7 +242,7 @@ const AssociatedStudiesTable = ({
   authorFilterOptions,
   authorFilterHandler,
 }) => (
-  <React.Fragment>
+  <Fragment>
     <DataDownloader
       tableHeaders={getDownloadColumns()}
       rows={getDownloadRows(data)}
@@ -280,8 +280,15 @@ const AssociatedStudiesTable = ({
           label: `gene:associated-studies:${sortBy}(${order})`,
         });
       }}
+      headerGroups={[
+        { colspan: 4, label: 'Study Information' },
+        {
+          colspan: 7,
+          label: 'Association Information',
+        },
+      ]}
     />
-  </React.Fragment>
+  </Fragment>
 );
 
 export default AssociatedStudiesTable;

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -79,6 +79,7 @@ const tableColumns = ({
       </Link>
     ),
   },
+
   {
     id: 'study.traitReported',
     label: 'Trait',
@@ -94,9 +95,10 @@ const tableColumns = ({
       />
     ),
   },
+
   {
     id: 'study.pubAuthor',
-    label: 'Author (Year)',
+    label: 'Publication',
     comparator: generateComparator(d => d.study.pubAuthor),
     renderFilter: () => (
       <Autocomplete
@@ -107,11 +109,26 @@ const tableColumns = ({
         multiple
       />
     ),
-    renderCell: rowData =>
-      `${rowData.study.pubAuthor} (${new Date(
+    renderCell: rowData => {
+      // Some studies don't have a pmid so need to avoid dead links
+      const url = rowData.study.pmid
+        ? `"http://europepmc.org/article/MED/${
+            rowData.study.pmid.split(':')[1]
+          }"`
+        : null;
+      const pub = `${rowData.study.pubAuthor} (${new Date(
         rowData.study.pubDate
-      ).getFullYear()})`,
+      ).getFullYear()})`;
+      return url ? (
+        <Link to={url} external>
+          {pub}
+        </Link>
+      ) : (
+        pub
+      );
+    },
   },
+
   {
     id: 'study.nInitial',
     label: 'N Initial',
@@ -119,6 +136,7 @@ const tableColumns = ({
     renderCell: rowData =>
       rowData.study.nInitial ? commaSeparate(rowData.study.nInitial) : '',
   },
+
   {
     id: 'variant.id',
     label: 'Lead Variant',
@@ -127,6 +145,7 @@ const tableColumns = ({
       <Link to={`/variant/${rowData.variant.id}`}>{rowData.variant.id}</Link>
     ),
   },
+
   {
     id: 'pval',
     label: 'P-value',
@@ -135,6 +154,7 @@ const tableColumns = ({
         ? `<${pvalThreshold}`
         : significantFigures(rowData.pval),
   },
+
   {
     id: 'beta.betaCI',
     label: 'Beta',
@@ -153,6 +173,7 @@ const tableColumns = ({
     renderCell: rowData =>
       rowData.beta.betaCI ? significantFigures(rowData.beta.betaCI) : null,
   },
+
   {
     id: 'odds.oddsCI',
     label: 'Odds Ratio',
@@ -160,6 +181,7 @@ const tableColumns = ({
     renderCell: rowData =>
       rowData.odds.oddsCI ? significantFigures(rowData.odds.oddsCI) : null,
   },
+
   {
     id: 'ci',
     label: '95% Confidence Interval',
@@ -176,6 +198,7 @@ const tableColumns = ({
             )}, ${significantFigures(rowData.odds.oddsCIUpper)})`
           : null,
   },
+
   {
     id: 'yProbaModel',
     label: 'L2G pipeline score',
@@ -183,6 +206,7 @@ const tableColumns = ({
     renderCell: rowData =>
       rowData.yProbaModel ? significantFigures(rowData.yProbaModel) : null,
   },
+
   {
     id: 'locusView',
     label: 'View',

--- a/src/components/AssociatedStudiesTable.js
+++ b/src/components/AssociatedStudiesTable.js
@@ -61,6 +61,7 @@ const getDownloadRows = rows => {
 
 const tableColumns = ({
   geneId,
+  geneSymbol,
   chromosome,
   position,
   traitFilterValue,
@@ -212,7 +213,7 @@ const tableColumns = ({
   {
     id: 'yProbaModel',
     label: 'L2G pipeline score',
-    tooltip: '',
+    tooltip: `Evidence linking ${geneSymbol} to this study via our locus-to-gene pipeline. Score range [0, 1].`,
     renderCell: rowData =>
       rowData.yProbaModel ? significantFigures(rowData.yProbaModel) : null,
   },
@@ -239,6 +240,7 @@ const AssociatedStudiesTable = ({
   filenameStem,
   data,
   geneId,
+  geneSymbol,
   chromosome,
   position,
   traitFilterValue,
@@ -260,6 +262,7 @@ const AssociatedStudiesTable = ({
       filters
       columns={tableColumns({
         geneId,
+        geneSymbol,
         chromosome,
         position,
         traitFilterValue,

--- a/src/components/ColocForGeneTable.js
+++ b/src/components/ColocForGeneTable.js
@@ -1,9 +1,75 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import * as d3 from 'd3';
 
-import { Link, OtTable, Autocomplete, significantFigures } from 'ot-ui';
+import {
+  Link,
+  OtTableRF,
+  Autocomplete,
+  significantFigures,
+  DataDownloader,
+} from 'ot-ui';
 
 import StudyLocusLink from './StudyLocusLink';
+
+const getDownloadColumns = () => {
+  return [
+    {
+      id: 'study',
+      label: 'Study',
+    },
+    {
+      id: 'traitReported',
+      label: 'Trait reported',
+    },
+    {
+      id: 'pubAuthor',
+      label: 'Author',
+    },
+    {
+      id: 'indexVariant',
+      label: 'Lead variant',
+    },
+    {
+      id: 'phenotypeId',
+      label: 'Phenotype',
+    },
+    {
+      id: 'tissueName',
+      label: 'Tissue',
+    },
+    {
+      id: 'qtlStudyId',
+      label: 'Source',
+    },
+    {
+      id: 'h3',
+      label: 'H3',
+    },
+    {
+      id: 'h4',
+      label: 'H4',
+    },
+    {
+      id: 'log2h4h3',
+      label: 'log2(H4/H3)',
+    },
+  ];
+};
+
+const getDownloadRows = rows => {
+  return rows.map(row => ({
+    study: row.study.studyId,
+    traitReported: row.study.traitReported,
+    pubAuthor: row.study.pubAuthor,
+    indexVariant: row.leftVariant.id,
+    phenotypeId: row.phenotypeId,
+    tissueName: row.tissue.name,
+    qtlStudyId: row.qtlStudyId,
+    h3: row.h3,
+    h4: row.h4,
+    log2h4h3: row.log2h4h3,
+  }));
+};
 
 const tableColumns = ({
   colocTraitFilterValue,
@@ -104,20 +170,27 @@ const ColocTable = ({
   colocTraitFilterOptions,
   colocTraitFilterHandler,
 }) => (
-  <OtTable
-    loading={loading}
-    error={error}
-    columns={tableColumns({
-      colocTraitFilterValue,
-      colocTraitFilterOptions,
-      colocTraitFilterHandler,
-    })}
-    filters
-    data={data}
-    sortBy="log2h4h3"
-    order="desc"
-    downloadFileStem={filenameStem}
-  />
+  <Fragment>
+    <DataDownloader
+      tableHeaders={getDownloadColumns()}
+      rows={getDownloadRows(data)}
+      fileStem={filenameStem}
+    />
+    <OtTableRF
+      loading={loading}
+      error={error}
+      columns={tableColumns({
+        colocTraitFilterValue,
+        colocTraitFilterOptions,
+        colocTraitFilterHandler,
+      })}
+      filters
+      data={data}
+      sortBy="log2h4h3"
+      order="desc"
+      downloadFileStem={filenameStem}
+    />
+  </Fragment>
 );
 
 export default ColocTable;

--- a/src/components/ColocL2GTable.js
+++ b/src/components/ColocL2GTable.js
@@ -41,14 +41,14 @@ const tableColumns = [
     comparator: (a, b) => d3.ascending(a.yProbaDistance, b.yProbaDistance),
     renderCell: d => significantFigures(d.yProbaDistance),
   },
-  {
-    id: 'yProbaInterlocus',
-    label: 'QTL Coloc',
-    tooltip:
-      'Evidence linking gene to this study including molecular trait colocalisation features only. Score range [0, 1].',
-    comparator: (a, b) => d3.ascending(a.yProbaInterlocus, b.yProbaInterlocus),
-    renderCell: d => significantFigures(d.yProbaInterlocus),
-  },
+  // {
+  //   id: 'yProbaInterlocus',
+  //   label: 'QTL Coloc',
+  //   tooltip:
+  //     'Evidence linking gene to this study including molecular trait colocalisation features only. Score range [0, 1].',
+  //   comparator: (a, b) => d3.ascending(a.yProbaInterlocus, b.yProbaInterlocus),
+  //   renderCell: d => significantFigures(d.yProbaInterlocus),
+  // },
   {
     id: 'yProbaInteraction',
     label: 'Chromatin Interaction',
@@ -80,7 +80,7 @@ const getDownloadColumns = () => {
 
     { id: 'yProbaPathogenicity', label: 'Variant Pathogenicity' },
     { id: 'yProbaDistance', label: 'Distance' },
-    { id: 'yProbaInterlocus', label: 'QTL Coloc' },
+    // { id: 'yProbaInterlocus', label: 'QTL Coloc' },
     { id: 'yProbaInteraction', label: 'Chromatin Interaction' },
 
     { id: 'distanceToLocus', label: 'Distance to Locus ' },
@@ -95,7 +95,7 @@ const getDownloadRows = data => {
     yProbaModel: d.yProbaModel,
     yProbaPathogenicity: d.yProbaPathogenicity,
     yProbaDistance: d.yProbaDistance,
-    yProbaInterlocus: d.yProbaInterlocus,
+    // yProbaInterlocus: d.yProbaInterlocus,
     yProbaInteraction: d.yProbaInteraction,
     distanceToLocus: d.distanceToLocus,
     hasColoc: d.hasColoc,

--- a/src/components/ColocL2GTable.js
+++ b/src/components/ColocL2GTable.js
@@ -113,6 +113,8 @@ const ColocL2GTable = ({ loading, error, fileStem, data }) => {
         error={error}
         columns={tableColumns}
         data={data}
+        sortBy="yProbaModel"
+        order="desc"
         headerGroups={[
           { colspan: 2, label: '' },
           {

--- a/src/components/ColocL2GTable.js
+++ b/src/components/ColocL2GTable.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import * as d3 from 'd3';
+
+import { Link, OtTableRF, DataDownloader, significantFigures } from 'ot-ui';
+
+import StudyLocusLink from './StudyLocusLink';
+
+const tableColumns = [
+  {
+    id: 'gene.symbol',
+    label: 'Gene',
+    comparator: (a, b) => d3.ascending(a.gene.symbol, b.gene.symbol),
+    renderCell: d => <Link to={`/gene/${d.gene.symbol}`}>{d.gene.symbol}</Link>,
+  },
+  {
+    id: 'yProbaModel',
+    label: 'Overall L2G score',
+    comparator: (a, b) => d3.ascending(a.yProbaModel, b.yProbaModel),
+    renderCell: d => d.yProbaModel,
+  },
+  {
+    id: 'yProbaPathogenicity',
+    label: 'Variant Pathogenicity',
+    comparator: (a, b) =>
+      d3.ascending(a.yProbaPathogenicity, b.yProbaPathogenicity),
+    renderCell: d => d.yProbaPathogenicity,
+  },
+  {
+    id: 'yProbaDistance',
+    label: 'Distance',
+    comparator: (a, b) => d3.ascending(a.yProbaDistance, b.yProbaDistance),
+    renderCell: d => (
+      <Link to={`/variant/${d.yProbaDistance}`}>{d.yProbaDistance}</Link>
+    ),
+  },
+  {
+    id: 'yProbaInterlocus',
+    label: 'QTL Coloc',
+    tooltip:
+      'Effect with respect to the alternative allele of the page variant',
+    renderCell: d => significantFigures(d.yProbaInterlocus),
+  },
+  {
+    id: 'yProbaInteraction',
+    label: 'Chromatin Interaction',
+    tooltip: (
+      <React.Fragment>
+        Posterior probability that the signals <strong>do not</strong>{' '}
+        colocalise
+      </React.Fragment>
+    ),
+    renderCell: d => significantFigures(d.yProbaInteraction),
+  },
+  {
+    id: 'yProbaDistance',
+    label: 'Distance to Locus ',
+    tooltip: 'Posterior probability that the signals colocalise',
+    renderCell: d => significantFigures(d.yProbaDistance),
+  },
+  {
+    id: 'hasColoc',
+    label: 'Evidence of colocalisation',
+    tooltip: 'Log-likelihood that the signals colocalise',
+    renderCell: d => (d.hasColoc ? 'yes' : 'no'),
+  },
+  {
+    id: 'locus',
+    label: 'View other evidence linking study-locus-gene',
+    renderCell: d => <Link>click</Link>,
+  },
+];
+
+const getDownloadData = data => {
+  return data.map(d => ({
+    study: d.study.studyId,
+    traitReported: d.study.traitReported,
+    pubAuthor: d.study.pubAuthor,
+    indexVariant: d.indexVariant.id,
+    beta: d.beta,
+    h3: d.h3,
+    h4: d.h4,
+    log2h4h3: d.log2h4h3,
+  }));
+};
+
+const ColocL2GTable = ({ loading, error, fileStem, data }) => {
+  console.log(data);
+  const downloadData = []; // getDownloadData(data);
+  return (
+    <React.Fragment>
+      <DataDownloader
+        tableHeaders={tableColumns}
+        rows={downloadData}
+        fileStem={fileStem}
+      />
+      <OtTableRF
+        loading={loading}
+        error={error}
+        columns={tableColumns}
+        data={data}
+        headerGroups={[
+          { colspan: 2, label: '' },
+          {
+            colspan: 4,
+            label: 'Partial L2G scores',
+          },
+          { colspan: 3, label: '' },
+        ]}
+      />
+    </React.Fragment>
+  );
+};
+
+export default ColocL2GTable;

--- a/src/components/ColocL2GTable.js
+++ b/src/components/ColocL2GTable.js
@@ -41,14 +41,15 @@ const tableColumns = [
     comparator: (a, b) => d3.ascending(a.yProbaDistance, b.yProbaDistance),
     renderCell: d => significantFigures(d.yProbaDistance),
   },
-  // {
-  //   id: 'yProbaInterlocus',
-  //   label: 'QTL Coloc',
-  //   tooltip:
-  //     'Evidence linking gene to this study including molecular trait colocalisation features only. Score range [0, 1].',
-  //   comparator: (a, b) => d3.ascending(a.yProbaInterlocus, b.yProbaInterlocus),
-  //   renderCell: d => significantFigures(d.yProbaInterlocus),
-  // },
+  {
+    id: 'yProbaMolecularQTL',
+    label: 'QTL Coloc',
+    tooltip:
+      'Evidence linking gene to this study including molecular trait colocalisation features only. Score range [0, 1].',
+    comparator: (a, b) =>
+      d3.ascending(a.yProbaMolecularQTL, b.yProbaMolecularQTL),
+    renderCell: d => significantFigures(d.yProbaMolecularQTL),
+  },
   {
     id: 'yProbaInteraction',
     label: 'Chromatin Interaction',
@@ -87,7 +88,7 @@ const getDownloadColumns = () => {
 
     { id: 'yProbaPathogenicity', label: 'Variant Pathogenicity' },
     { id: 'yProbaDistance', label: 'Distance' },
-    // { id: 'yProbaInterlocus', label: 'QTL Coloc' },
+    { id: 'yProbaMolecularQTL', label: 'QTL Coloc' },
     { id: 'yProbaInteraction', label: 'Chromatin Interaction' },
 
     { id: 'distanceToLocus', label: 'Distance to Locus ' },
@@ -102,7 +103,7 @@ const getDownloadRows = data => {
     yProbaModel: d.yProbaModel,
     yProbaPathogenicity: d.yProbaPathogenicity,
     yProbaDistance: d.yProbaDistance,
-    // yProbaInterlocus: d.yProbaInterlocus,
+    yProbaMolecularQTL: d.yProbaMolecularQTL,
     yProbaInteraction: d.yProbaInteraction,
     distanceToLocus: d.distanceToLocus,
     hasColoc: d.hasColoc,

--- a/src/components/ColocL2GTable.js
+++ b/src/components/ColocL2GTable.js
@@ -54,7 +54,7 @@ const tableColumns = [
   },
   {
     id: 'distanceToLocus',
-    label: 'Distance to Locus ',
+    label: 'Distance to locus (bp)',
     comparator: (a, b) => d3.ascending(a.distanceToLocus, b.distanceToLocus),
     renderCell: d => d.distanceToLocus,
   },

--- a/src/components/ColocL2GTable.js
+++ b/src/components/ColocL2GTable.js
@@ -13,12 +13,16 @@ const tableColumns = [
   {
     id: 'yProbaModel',
     label: 'Overall L2G score',
+    tooltip:
+      'Overall evidence linking gene to this study using all features. Score range [0, 1].',
     comparator: (a, b) => d3.ascending(a.yProbaModel, b.yProbaModel),
     renderCell: d => significantFigures(d.yProbaModel),
   },
   {
     id: 'yProbaPathogenicity',
     label: 'Variant Pathogenicity',
+    tooltip:
+      'Evidence linking gene to this study including variant pathogenicity features only. Score range [0, 1].',
     comparator: (a, b) =>
       d3.ascending(a.yProbaPathogenicity, b.yProbaPathogenicity),
     renderCell: d => significantFigures(d.yProbaPathogenicity),
@@ -26,18 +30,24 @@ const tableColumns = [
   {
     id: 'yProbaDistance',
     label: 'Distance',
+    tooltip:
+      'Evidence linking gene to this study including distance features only. Score range [0, 1].',
     comparator: (a, b) => d3.ascending(a.yProbaDistance, b.yProbaDistance),
     renderCell: d => significantFigures(d.yProbaDistance),
   },
   {
     id: 'yProbaInterlocus',
     label: 'QTL Coloc',
+    tooltip:
+      'Evidence linking gene to this study including molecular trait colocalisation features only. Score range [0, 1].',
     comparator: (a, b) => d3.ascending(a.yProbaInterlocus, b.yProbaInterlocus),
     renderCell: d => significantFigures(d.yProbaInterlocus),
   },
   {
     id: 'yProbaInteraction',
     label: 'Chromatin Interaction',
+    tooltip:
+      'Evidence linking gene to this study including chromatin interaction features only. Score range [0, 1].',
     comparator: (a, b) =>
       d3.ascending(a.yProbaInteraction, b.yProbaInteraction),
     renderCell: d => significantFigures(d.yProbaInteraction),
@@ -51,7 +61,6 @@ const tableColumns = [
   {
     id: 'hasColoc',
     label: 'Evidence of colocalisation',
-    tooltip: 'TODO -- tooltip help text',
     renderCell: d => (d.hasColoc ? <a href="#coloc">Yes</a> : 'No'),
   },
   {

--- a/src/components/ColocL2GTable.js
+++ b/src/components/ColocL2GTable.js
@@ -3,8 +3,6 @@ import * as d3 from 'd3';
 
 import { Link, OtTableRF, DataDownloader, significantFigures } from 'ot-ui';
 
-// import StudyLocusLink from './StudyLocusLink';
-
 const tableColumns = [
   {
     id: 'gene.symbol',
@@ -48,13 +46,13 @@ const tableColumns = [
     id: 'distanceToLocus',
     label: 'Distance to Locus ',
     comparator: (a, b) => d3.ascending(a.distanceToLocus, b.distanceToLocus),
-    renderCell: d => significantFigures(d.distanceToLocus),
+    renderCell: d => d.distanceToLocus,
   },
   {
     id: 'hasColoc',
     label: 'Evidence of colocalisation',
-    tooltip: 'Log-likelihood that the signals colocalise',
-    renderCell: d => (d.hasColoc ? 'Yes' : 'No'),
+    tooltip: 'TODO -- tooltip help text',
+    renderCell: d => (d.hasColoc ? <a href="#coloc">Yes</a> : 'No'),
   },
   {
     id: 'locus',

--- a/src/components/ColocL2GTable.js
+++ b/src/components/ColocL2GTable.js
@@ -68,7 +68,14 @@ const tableColumns = [
   {
     id: 'hasColoc',
     label: 'Evidence of colocalisation',
-    renderCell: d => (d.hasColoc ? <a href="#coloc">Yes</a> : 'No'),
+    renderCell: d =>
+      d.hasColoc ? (
+        <a href="#coloc" style={{ color: '#3489ca', textDecoration: 'none' }}>
+          Yes
+        </a>
+      ) : (
+        'No'
+      ),
   },
 ];
 

--- a/src/components/ColocL2GTable.js
+++ b/src/components/ColocL2GTable.js
@@ -3,94 +3,102 @@ import * as d3 from 'd3';
 
 import { Link, OtTableRF, DataDownloader, significantFigures } from 'ot-ui';
 
-import StudyLocusLink from './StudyLocusLink';
+// import StudyLocusLink from './StudyLocusLink';
 
 const tableColumns = [
   {
     id: 'gene.symbol',
     label: 'Gene',
     comparator: (a, b) => d3.ascending(a.gene.symbol, b.gene.symbol),
-    renderCell: d => <Link to={`/gene/${d.gene.symbol}`}>{d.gene.symbol}</Link>,
+    renderCell: d => <Link to={`/gene/${d.gene.id}`}>{d.gene.symbol}</Link>,
   },
   {
     id: 'yProbaModel',
     label: 'Overall L2G score',
     comparator: (a, b) => d3.ascending(a.yProbaModel, b.yProbaModel),
-    renderCell: d => d.yProbaModel,
+    renderCell: d => significantFigures(d.yProbaModel),
   },
   {
     id: 'yProbaPathogenicity',
     label: 'Variant Pathogenicity',
     comparator: (a, b) =>
       d3.ascending(a.yProbaPathogenicity, b.yProbaPathogenicity),
-    renderCell: d => d.yProbaPathogenicity,
+    renderCell: d => significantFigures(d.yProbaPathogenicity),
   },
   {
     id: 'yProbaDistance',
     label: 'Distance',
     comparator: (a, b) => d3.ascending(a.yProbaDistance, b.yProbaDistance),
-    renderCell: d => (
-      <Link to={`/variant/${d.yProbaDistance}`}>{d.yProbaDistance}</Link>
-    ),
+    renderCell: d => significantFigures(d.yProbaDistance),
   },
   {
     id: 'yProbaInterlocus',
     label: 'QTL Coloc',
-    tooltip:
-      'Effect with respect to the alternative allele of the page variant',
+    comparator: (a, b) => d3.ascending(a.yProbaInterlocus, b.yProbaInterlocus),
     renderCell: d => significantFigures(d.yProbaInterlocus),
   },
   {
     id: 'yProbaInteraction',
     label: 'Chromatin Interaction',
-    tooltip: (
-      <React.Fragment>
-        Posterior probability that the signals <strong>do not</strong>{' '}
-        colocalise
-      </React.Fragment>
-    ),
+    comparator: (a, b) =>
+      d3.ascending(a.yProbaInteraction, b.yProbaInteraction),
     renderCell: d => significantFigures(d.yProbaInteraction),
   },
   {
-    id: 'yProbaDistance',
+    id: 'distanceToLocus',
     label: 'Distance to Locus ',
-    tooltip: 'Posterior probability that the signals colocalise',
-    renderCell: d => significantFigures(d.yProbaDistance),
+    comparator: (a, b) => d3.ascending(a.distanceToLocus, b.distanceToLocus),
+    renderCell: d => significantFigures(d.distanceToLocus),
   },
   {
     id: 'hasColoc',
     label: 'Evidence of colocalisation',
     tooltip: 'Log-likelihood that the signals colocalise',
-    renderCell: d => (d.hasColoc ? 'yes' : 'no'),
+    renderCell: d => (d.hasColoc ? 'Yes' : 'No'),
   },
   {
     id: 'locus',
     label: 'View other evidence linking study-locus-gene',
-    renderCell: d => <Link>click</Link>,
+    renderCell: d => <Link>Platform Evidence</Link>,
   },
 ];
 
-const getDownloadData = data => {
+const getDownloadColumns = () => {
+  return [
+    { id: 'geneSymbol', label: 'Gene' },
+    { id: 'geneId', label: 'Gene ID' },
+    { id: 'yProbaModel', label: 'Overall L2G score' },
+
+    { id: 'yProbaPathogenicity', label: 'Variant Pathogenicity' },
+    { id: 'yProbaDistance', label: 'Distance' },
+    { id: 'yProbaInterlocus', label: 'QTL Coloc' },
+    { id: 'yProbaInteraction', label: 'Chromatin Interaction' },
+
+    { id: 'distanceToLocus', label: 'Distance to Locus ' },
+    { id: 'hasColoc', label: 'Evidence of colocalisation' },
+  ];
+};
+
+const getDownloadRows = data => {
   return data.map(d => ({
-    study: d.study.studyId,
-    traitReported: d.study.traitReported,
-    pubAuthor: d.study.pubAuthor,
-    indexVariant: d.indexVariant.id,
-    beta: d.beta,
-    h3: d.h3,
-    h4: d.h4,
-    log2h4h3: d.log2h4h3,
+    geneSymbol: d.gene.symbol,
+    geneId: d.gene.id,
+    yProbaModel: d.yProbaModel,
+    yProbaPathogenicity: d.yProbaPathogenicity,
+    yProbaDistance: d.yProbaDistance,
+    yProbaInterlocus: d.yProbaInterlocus,
+    yProbaInteraction: d.yProbaInteraction,
+    distanceToLocus: d.distanceToLocus,
+    hasColoc: d.hasColoc,
   }));
 };
 
 const ColocL2GTable = ({ loading, error, fileStem, data }) => {
-  console.log(data);
-  const downloadData = []; // getDownloadData(data);
   return (
     <React.Fragment>
       <DataDownloader
-        tableHeaders={tableColumns}
-        rows={downloadData}
+        tableHeaders={getDownloadColumns()}
+        rows={getDownloadRows(data)}
         fileStem={fileStem}
       />
       <OtTableRF

--- a/src/components/ColocL2GTable.js
+++ b/src/components/ColocL2GTable.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import * as d3 from 'd3';
 
-import { Link, OtTableRF, DataDownloader, significantFigures } from 'ot-ui';
+import {
+  Link,
+  OtTableRF,
+  DataDownloader,
+  significantFigures,
+  commaSeparate,
+} from 'ot-ui';
 
 const tableColumns = [
   {
@@ -56,7 +62,8 @@ const tableColumns = [
     id: 'distanceToLocus',
     label: 'Distance to locus (bp)',
     comparator: (a, b) => d3.ascending(a.distanceToLocus, b.distanceToLocus),
-    renderCell: d => d.distanceToLocus,
+    renderCell: d =>
+      d.distanceToLocus ? commaSeparate(d.distanceToLocus) : '',
   },
   {
     id: 'hasColoc',

--- a/src/components/ColocL2GTable.js
+++ b/src/components/ColocL2GTable.js
@@ -70,11 +70,6 @@ const tableColumns = [
     label: 'Evidence of colocalisation',
     renderCell: d => (d.hasColoc ? <a href="#coloc">Yes</a> : 'No'),
   },
-  {
-    id: 'locus',
-    label: 'View other evidence linking study-locus-gene',
-    renderCell: d => <Link>Platform Evidence</Link>,
-  },
 ];
 
 const getDownloadColumns = () => {

--- a/src/components/ManhattanContainer.js
+++ b/src/components/ManhattanContainer.js
@@ -40,6 +40,7 @@ function transformAssociations(data) {
       chromosome: variant.chromosome,
       position: variant.position,
       globalPosition: ch.cumulativeLength - ch.length + variant.position,
+      nearestCodingGene: variant.nearestCodingGene,
     };
   });
 }

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -108,7 +108,7 @@ export const tableColumns = (studyId, hasSumsStats) => [
   {
     id: 'bestGenes',
     label: 'Closest Gene',
-    tooltip: 'The closest gene with the closest transcription start site',
+    tooltip: 'The gene with the closest transcription start site',
     renderCell: rowData => (
       <React.Fragment>
         {rowData.bestGenes.map((d, i) => (

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -92,15 +92,31 @@ export const tableColumns = (studyId, hasSumsStats) => [
       rowData.ldSetSize ? commaSeparate(rowData.ldSetSize) : null,
   },
   {
-    id: 'bestGenes',
+    id: 'bestLocus2Genes',
     label: 'L2G',
     tooltip:
       'The top ranked genes from our variant-to-gene pipeline for this lead variant',
     renderCell: rowData => (
       <React.Fragment>
+        {rowData.bestLocus2Genes.map((d, i) => (
+          <React.Fragment key={i}>
+            {i > 0 ? ', ' : ''}
+            <Link to={`/gene/${d.gene.id}`}>{d.gene.symbol}</Link>
+          </React.Fragment>
+        ))}
+      </React.Fragment>
+    ),
+  },
+  {
+    id: 'bestGenes',
+    label: 'Closest Gene',
+    tooltip: '', // TODO: need tooltip text
+    renderCell: rowData => (
+      <React.Fragment>
         {rowData.bestGenes.map((d, i) => (
           <React.Fragment key={i}>
-            <Link to={`/gene/${d.gene.id}`}>{d.gene.symbol}</Link>{' '}
+            {i > 0 ? ', ' : ''}
+            <Link to={`/gene/${d.gene.id}`}>{d.gene.symbol}</Link>
           </React.Fragment>
         ))}
       </React.Fragment>
@@ -115,7 +131,8 @@ export const tableColumns = (studyId, hasSumsStats) => [
       <React.Fragment>
         {rowData.bestColocGenes.map((d, i) => (
           <React.Fragment key={i}>
-            <Link to={`/gene/${d.gene.id}`}>{d.gene.symbol}</Link>{' '}
+            {i > 0 ? ', ' : ''}
+            <Link to={`/gene/${d.gene.id}`}>{d.gene.symbol}</Link>
           </React.Fragment>
         ))}
       </React.Fragment>

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -106,18 +106,13 @@ export const tableColumns = (studyId, hasSumsStats) => [
     ),
   },
   {
-    id: 'bestGenes',
+    id: 'nearestCodingGene.id',
     label: 'Closest Gene',
     tooltip: 'The gene with the closest transcription start site',
     renderCell: rowData => (
-      <React.Fragment>
-        {rowData.bestGenes.map((d, i) => (
-          <React.Fragment key={i}>
-            {i > 0 ? ', ' : ''}
-            <Link to={`/gene/${d.gene.id}`}>{d.gene.symbol}</Link>
-          </React.Fragment>
-        ))}
-      </React.Fragment>
+      <Link to={`/gene/${rowData.nearestCodingGene.id}`}>
+        {rowData.nearestCodingGene.symbol}
+      </Link>
     ),
   },
   {

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -126,12 +126,6 @@ export const tableColumns = (studyId, hasSumsStats) => [
     label: 'View',
     renderCell: rowData => (
       <React.Fragment>
-        <LocusLink
-          chromosome={rowData.chromosome}
-          position={rowData.position}
-          selectedIndexVariants={[rowData.indexVariantId]}
-          selectedStudies={[studyId]}
-        />
         <StudyLocusLink
           hasSumsStats={hasSumsStats}
           indexVariantId={rowData.indexVariantId}

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -93,7 +93,7 @@ export const tableColumns = (studyId, hasSumsStats) => [
   },
   {
     id: 'bestGenes',
-    label: 'Top V2G Genes',
+    label: 'L2G',
     tooltip:
       'The top ranked genes from our variant-to-gene pipeline for this lead variant',
     renderCell: rowData => (
@@ -108,7 +108,7 @@ export const tableColumns = (studyId, hasSumsStats) => [
   },
   {
     id: 'bestColocGenes',
-    label: 'Top Colocalising Genes',
+    label: 'Colocalisation',
     tooltip:
       'The list of genes which colocalise at this locus with PP(H4) ≥ 0.95 and log2(H4/H3) ≥ log2(5)',
     renderCell: rowData => (

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -106,7 +106,7 @@ export const tableColumns = (studyId, hasSumsStats) => [
     ),
   },
   {
-    id: 'nearestCodingGene.id',
+    id: 'nearestCodingGene',
     label: 'Closest Gene',
     tooltip: 'The gene with the closest transcription start site',
     renderCell: rowData => (
@@ -170,7 +170,9 @@ const getDownloadData = dataWithCytoband => {
           : null,
       credibleSetSize: row.credibleSetSize,
       ldSetSize: row.ldSetSize,
-      bestGenes: row.bestGenes.map(d => d.gene.symbol).join(', '),
+      bestLocus2Genes: row.bestLocus2Genes.map(d => d.gene.symbol).join(', '),
+      nearestCodingGene: row.nearestCodingGene.symbol,
+      bestColocGenes: row.bestColocGenes.map(d => d.gene.symbol).join(', '),
     };
   });
 };

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -9,12 +9,10 @@ import {
 } from 'ot-ui';
 import { getCytoband } from 'ot-charts';
 
-import LocusLink from './LocusLink';
 import StudyLocusLink from './StudyLocusLink';
 import { pvalThreshold } from '../constants';
 import variantIdComparator from '../logic/variantIdComparator';
 import reportAnalyticsEvent from '../analytics/reportAnalyticsEvent';
-import cytobandComparator from '../logic/cytobandComparator';
 
 export const tableColumns = (studyId, hasSumsStats) => [
   {

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -92,8 +92,7 @@ export const tableColumns = (studyId, hasSumsStats) => [
   {
     id: 'bestLocus2Genes',
     label: 'L2G',
-    tooltip:
-      'Genes prioritised by our locus-to-gene model with posterior probability ≥ 0.5',
+    tooltip: 'Genes prioritised by our locus-to-gene model with score ≥ 0.5',
     renderCell: rowData => (
       <React.Fragment>
         {rowData.bestLocus2Genes.map((d, i) => (

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -28,15 +28,6 @@ export const tableColumns = (studyId, hasSumsStats) => [
     comparator: variantIdComparator,
   },
   {
-    id: 'indexVariantRsId',
-    label: 'rsID',
-  },
-  {
-    id: 'cytoband',
-    label: 'Cytoband',
-    comparator: cytobandComparator,
-  },
-  {
     id: 'pval',
     label: 'P-value',
     renderCell: rowData =>

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -93,7 +93,7 @@ export const tableColumns = (studyId, hasSumsStats) => [
     id: 'bestLocus2Genes',
     label: 'L2G',
     tooltip:
-      'The top ranked genes from our variant-to-gene pipeline for this lead variant',
+      'Genes prioritised by our locus-to-gene model with posterior probability ≥ 0.5',
     renderCell: rowData => (
       <React.Fragment>
         {rowData.bestLocus2Genes.map((d, i) => (
@@ -108,7 +108,7 @@ export const tableColumns = (studyId, hasSumsStats) => [
   {
     id: 'bestGenes',
     label: 'Closest Gene',
-    tooltip: '', // TODO: need tooltip text
+    tooltip: 'The closest gene with the closest transcription start site',
     renderCell: rowData => (
       <React.Fragment>
         {rowData.bestGenes.map((d, i) => (
@@ -229,7 +229,16 @@ function ManhattanTable({
         }}
         headerGroups={[
           { colspan: 7, label: 'Association Information' },
-          { colspan: 5, label: 'Prioritised Genes' },
+          {
+            colspan: 5,
+            label: (
+              <Fragment>
+                Prioritised Genes
+                <br />
+                <small>results from our gene prioritisation pipelines</small>
+              </Fragment>
+            ),
+          },
         ]}
       />
     </Fragment>

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -109,11 +109,12 @@ export const tableColumns = (studyId, hasSumsStats) => [
     id: 'nearestCodingGene',
     label: 'Closest Gene',
     tooltip: 'The gene with the closest transcription start site',
-    renderCell: rowData => (
-      <Link to={`/gene/${rowData.nearestCodingGene.id}`}>
-        {rowData.nearestCodingGene.symbol}
-      </Link>
-    ),
+    renderCell: rowData =>
+      rowData.nearestCodingGene ? (
+        <Link to={`/gene/${rowData.nearestCodingGene.id}`}>
+          {rowData.nearestCodingGene.symbol}
+        </Link>
+      ) : null,
   },
   {
     id: 'bestColocGenes',
@@ -171,7 +172,9 @@ const getDownloadData = dataWithCytoband => {
       credibleSetSize: row.credibleSetSize,
       ldSetSize: row.ldSetSize,
       bestLocus2Genes: row.bestLocus2Genes.map(d => d.gene.symbol).join(', '),
-      nearestCodingGene: row.nearestCodingGene.symbol,
+      nearestCodingGene: row.nearestCodingGene
+        ? row.nearestCodingGene.symbol
+        : '',
       bestColocGenes: row.bestColocGenes.map(d => d.gene.symbol).join(', '),
     };
   });

--- a/src/components/ManhattanTable.js
+++ b/src/components/ManhattanTable.js
@@ -218,6 +218,10 @@ function ManhattanTable({
             label: `study:manhattan:${sortBy}(${order})`,
           });
         }}
+        headerGroups={[
+          { colspan: 7, label: 'Association Information' },
+          { colspan: 5, label: 'Prioritised Genes' },
+        ]}
       />
     </Fragment>
   );

--- a/src/components/StudyLocusLink.js
+++ b/src/components/StudyLocusLink.js
@@ -48,31 +48,19 @@ const StudyLocusLink = ({
 }) => {
   return (
     <Tooltip
-      title={
-        hasSumsStats
-          ? 'View colocalisation results at this locus'
-          : 'Colocalisation results are only available for studies that have summary statistics'
-      }
+      title="View gene prioritisation results for this locus"
       placement="top"
     >
-      {hasSumsStats ? (
-        <div className={classes.container}>
-          <Link
-            to={`/study-locus/${studyId}/${indexVariantId}`}
-            className={classes.link}
-          >
-            <Button className={big ? classes.buttonBig : classes.button}>
-              {label || 'Gene Prioritisation'}
-            </Button>
-          </Link>
-        </div>
-      ) : (
-        <div className={classes.container}>
-          <Button disabled className={big ? classes.buttonBig : classes.button}>
+      <div className={classes.container}>
+        <Link
+          to={`/study-locus/${studyId}/${indexVariantId}`}
+          className={classes.link}
+        >
+          <Button className={big ? classes.buttonBig : classes.button}>
             {label || 'Gene Prioritisation'}
           </Button>
-        </div>
-      )}
+        </Link>
+      </div>
     </Tooltip>
   );
 };

--- a/src/components/StudyLocusLink.js
+++ b/src/components/StudyLocusLink.js
@@ -61,14 +61,14 @@ const StudyLocusLink = ({
             className={classes.link}
           >
             <Button className={big ? classes.buttonBig : classes.button}>
-              Colocalisation
+              Gene Prioritisation
             </Button>
           </Link>
         </div>
       ) : (
         <div className={classes.container}>
           <Button disabled className={big ? classes.buttonBig : classes.button}>
-            Colocalisation
+            Gene Prioritisation
           </Button>
         </div>
       )}

--- a/src/components/StudyLocusLink.js
+++ b/src/components/StudyLocusLink.js
@@ -44,6 +44,7 @@ const StudyLocusLink = ({
   indexVariantId,
   classes,
   hasSumsStats,
+  label,
 }) => {
   return (
     <Tooltip
@@ -61,14 +62,14 @@ const StudyLocusLink = ({
             className={classes.link}
           >
             <Button className={big ? classes.buttonBig : classes.button}>
-              Gene Prioritisation
+              {label || 'Gene Prioritisation'}
             </Button>
           </Link>
         </div>
       ) : (
         <div className={classes.container}>
           <Button disabled className={big ? classes.buttonBig : classes.button}>
-            Gene Prioritisation
+            {label || 'Gene Prioritisation'}
           </Button>
         </div>
       )}

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,8 +1,7 @@
 import pkg from '../package.json';
 
 const defaults = {
-  // REACT_APP_GRAPHQL_API_URL: 'https://genetics-api.opentargets.io',
-  REACT_APP_GRAPHQL_API_URL: 'https://open-targets-genetics.appspot.com',
+  REACT_APP_GRAPHQL_API_URL: 'https://genetics-api.opentargets.io',
   REACT_APP_PLATFORM_URL: 'https://www.targetvalidation.org',
   REACT_APP_GIT_REVISION: '2222ccc',
   REACT_APP_CONTACT_URL: 'mailto:geneticsportal@opentargets.org',

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,7 +1,8 @@
 import pkg from '../package.json';
 
 const defaults = {
-  REACT_APP_GRAPHQL_API_URL: 'https://genetics-api.opentargets.io',
+  // REACT_APP_GRAPHQL_API_URL: 'https://genetics-api.opentargets.io',
+  REACT_APP_GRAPHQL_API_URL: 'https://open-targets-genetics.appspot.com',
   REACT_APP_PLATFORM_URL: 'https://www.targetvalidation.org',
   REACT_APP_GIT_REVISION: '2222ccc',
   REACT_APP_CONTACT_URL: 'mailto:geneticsportal@opentargets.org',

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -423,7 +423,7 @@ class GenePage extends React.Component {
                   </Grid>
                 </Grid>
                 <SectionHeading
-                  heading={`Associated studies`}
+                  heading="Associated studies: locus-to-gene pipeline"
                   subheading={`Which studies are associated with ${symbol}?`}
                   entities={[
                     {
@@ -452,7 +452,7 @@ class GenePage extends React.Component {
                   filenameStem={`${geneId}-associated-studies`}
                 />
                 <SectionHeading
-                  heading={`Colocalising studies`}
+                  heading="Associated studies: Colocalisation analysis"
                   subheading={`Which studies have evidence of colocalisation with molecular QTLs for ${symbol}?`}
                 />
                 <ColocForGeneTable

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -38,7 +38,7 @@ function geneData(data) {
 }
 
 function hasAssociatedStudies(data) {
-  return data && data.studiesAndLeadVariantsForGene;
+  return data && data.studiesAndLeadVariantsForGeneByL2G;
 }
 
 const styles = theme => {
@@ -171,7 +171,7 @@ class GenePage extends React.Component {
             // all
             const associatedStudies =
               isValidGene && hasAssociatedStudies(data)
-                ? data.studiesAndLeadVariantsForGene
+                ? data.studiesAndLeadVariantsForGeneByL2G
                 : [];
 
             // filtered

--- a/src/pages/GenePage.js
+++ b/src/pages/GenePage.js
@@ -441,6 +441,7 @@ class GenePage extends React.Component {
                   error={error}
                   data={associatedStudiesFiltered}
                   geneId={geneId}
+                  geneSymbol={symbol}
                   chromosome={chromosome}
                   position={Math.round((start + end) / 2)}
                   traitFilterValue={traitFilterValue}

--- a/src/pages/StudyLocusPage.js
+++ b/src/pages/StudyLocusPage.js
@@ -411,13 +411,8 @@ query CredibleSetsQuery {
                 </Typography>
 
                 <SectionHeading
-                  heading="New stuff goes here..."
-                  subheading={
-                    <React.Fragment>
-                      With some more details on{' '}
-                      <strong>{traitAuthorYear(studyInfo)}</strong> here?
-                    </React.Fragment>
-                  }
+                  heading="Gene prioritisation using locus-to-gene pipeline"
+                  subheading="Which genes were prioritised by L2G pipeline at this locus?"
                 />
                 <ColocL2GTable
                   loading={false}
@@ -428,7 +423,7 @@ query CredibleSetsQuery {
                 />
 
                 <SectionHeading
-                  heading="QTL Colocalisation"
+                  heading="Gene prioritisation using colocalisation analysis"
                   subheading={
                     <React.Fragment>
                       Which molecular traits colocalise with{' '}

--- a/src/pages/StudyLocusPage.js
+++ b/src/pages/StudyLocusPage.js
@@ -419,7 +419,7 @@ query CredibleSetsQuery {
                   error={false}
                   data={studyLocus2GeneTable.rows}
                   handleToggleRegional={this.handleToggleRegional}
-                  fileStem={`gwas-coloc-${studyId}-${indexVariantId}`}
+                  fileStem={`l2g-assignment-${studyId}-${indexVariantId}`}
                 />
 
                 <SectionHeading

--- a/src/pages/StudyLocusPage.js
+++ b/src/pages/StudyLocusPage.js
@@ -294,6 +294,7 @@ class LocusTraitPage extends React.Component {
               qtlColocalisation,
               // gwasColocalisationForRegion,
               pageCredibleSet,
+              pageSummary,
               genes,
               studyLocus2GeneTable,
             } = data;
@@ -325,9 +326,11 @@ query CredibleSetsQuery {
               .sort(log2h4h3Comparator)
               .reverse();
 
-            const associationSummary =
+            const associationSummary = pageSummary;
+            const associationSummarySE = (
               pageCredibleSet.find(d => d.tagVariant.id === indexVariantId) ||
-              {};
+              {}
+            ).se;
 
             const pageCredibleSetAdjusted = pageCredibleSet
               .map(flattenPosition)
@@ -386,28 +389,51 @@ query CredibleSetsQuery {
                 </Grid>
 
                 <SectionHeading heading="Association summary" />
+
                 <Typography variant="subtitle2">
                   <strong>P-value:</strong>{' '}
-                  {significantFigures(associationSummary.pval)}
+                  {significantFigures(associationSummary.pvalMantissa) +
+                    'e' +
+                    associationSummary.pvalExponent}
                 </Typography>
-                <Typography variant="subtitle2">
-                  <strong>Beta:</strong>{' '}
-                  {significantFigures(associationSummary.beta)}
-                </Typography>
-                <Typography variant="subtitle2">
-                  <strong>Beta 95% Confidence Interval:</strong> (
-                  {significantFigures(
-                    associationSummary.beta - 1.959 * associationSummary.se
-                  )}
-                  ,{' '}
-                  {significantFigures(
-                    associationSummary.beta + 1.959 * associationSummary.se
-                  )}
-                  )
-                </Typography>
+
+                {associationSummary.beta ? (
+                  <>
+                    <Typography variant="subtitle2">
+                      <strong>Beta:</strong>{' '}
+                      {significantFigures(associationSummary.beta)}
+                    </Typography>
+
+                    <Typography variant="subtitle2">
+                      <strong>Beta 95% Confidence Interval:</strong> (
+                      {significantFigures(associationSummary.betaCILower)},{' '}
+                      {significantFigures(associationSummary.betaCIUpper)})
+                    </Typography>
+                  </>
+                ) : associationSummary.oddsRatio ? (
+                  <>
+                    <Typography variant="subtitle2">
+                      <strong>Odds ratio:</strong>{' '}
+                      {significantFigures(associationSummary.oddsRatio)}
+                    </Typography>
+
+                    <Typography variant="subtitle2">
+                      <strong>Odds ratio Confidence Interval:</strong> (
+                      {significantFigures(associationSummary.oddsRatioCILower)},{' '}
+                      {significantFigures(associationSummary.oddsRatioCIUpper)})
+                    </Typography>
+                  </>
+                ) : (
+                  <Typography variant="subtitle2">
+                    <strong>Beta:</strong> N/A
+                  </Typography>
+                )}
+
                 <Typography variant="subtitle2">
                   <strong>Standard Error:</strong>{' '}
-                  {significantFigures(associationSummary.se)}
+                  {associationSummarySE
+                    ? significantFigures(associationSummarySE)
+                    : 'N/A'}
                 </Typography>
 
                 <SectionHeading

--- a/src/pages/StudyLocusPage.js
+++ b/src/pages/StudyLocusPage.js
@@ -27,6 +27,7 @@ import BasePage from './BasePage';
 import ColocQTLTable from '../components/ColocQTLTable';
 import ColocQTLGeneTissueTable from '../components/ColocQTLGeneTissueTable';
 import ColocGWASTable from '../components/ColocGWASTable';
+import ColocL2GTable from '../components/ColocL2GTable';
 // import ColocGWASHeatmapTable from '../components/ColocGWASHeatmapTable';
 import CredibleSetWithRegional from '../components/CredibleSetWithRegional';
 import CredibleSetsIntersectionTable from '../components/CredibleSetsIntersectionTable';
@@ -294,6 +295,7 @@ class LocusTraitPage extends React.Component {
               // gwasColocalisationForRegion,
               pageCredibleSet,
               genes,
+              studyLocus2GeneTable,
             } = data;
 
             const maxQTLLog2h4h3 = d3.max(qtlColocalisation, d => d.log2h4h3);
@@ -407,6 +409,24 @@ query CredibleSetsQuery {
                   <strong>Standard Error:</strong>{' '}
                   {significantFigures(associationSummary.se)}
                 </Typography>
+
+                <SectionHeading
+                  heading="New stuff goes here..."
+                  subheading={
+                    <React.Fragment>
+                      With some more details on{' '}
+                      <strong>{traitAuthorYear(studyInfo)}</strong> here?
+                    </React.Fragment>
+                  }
+                />
+                <ColocL2GTable
+                  loading={false}
+                  error={false}
+                  data={studyLocus2GeneTable.rows}
+                  handleToggleRegional={this.handleToggleRegional}
+                  fileStem={`gwas-coloc-${studyId}-${indexVariantId}`}
+                />
+
                 <SectionHeading
                   heading="QTL Colocalisation"
                   subheading={

--- a/src/pages/StudyLocusPage.js
+++ b/src/pages/StudyLocusPage.js
@@ -469,7 +469,7 @@ query CredibleSetsQuery {
                 ) : null}
 
                 <SectionHeading
-                  heading="GWAS Study Colocalisation"
+                  heading={<div id="coloc">GWAS Study Colocalisation</div>}
                   subheading={
                     <React.Fragment>
                       Which GWAS studies colocalise with{' '}

--- a/src/pages/StudyLocusPage.js
+++ b/src/pages/StudyLocusPage.js
@@ -327,10 +327,6 @@ query CredibleSetsQuery {
               .reverse();
 
             const associationSummary = pageSummary;
-            const associationSummarySE = (
-              pageCredibleSet.find(d => d.tagVariant.id === indexVariantId) ||
-              {}
-            ).se;
 
             const pageCredibleSetAdjusted = pageCredibleSet
               .map(flattenPosition)
@@ -428,13 +424,6 @@ query CredibleSetsQuery {
                     <strong>Beta:</strong> N/A
                   </Typography>
                 )}
-
-                <Typography variant="subtitle2">
-                  <strong>Standard Error:</strong>{' '}
-                  {associationSummarySE
-                    ? significantFigures(associationSummarySE)
-                    : 'N/A'}
-                </Typography>
 
                 <SectionHeading
                   heading="Gene prioritisation using locus-to-gene pipeline"

--- a/src/queries/GenePageQuery.gql
+++ b/src/queries/GenePageQuery.gql
@@ -17,6 +17,7 @@ query GenePageQuery($geneId: String!) {
       pubDate
       pmid
       nInitial
+      hasSumsStats
     }
     variant {
       rsId

--- a/src/queries/GenePageQuery.gql
+++ b/src/queries/GenePageQuery.gql
@@ -17,6 +17,7 @@ query GenePageQuery($geneId: String!) {
       pubDate
       pmid
       nInitial
+      nReplication
       hasSumsStats
     }
     variant {

--- a/src/queries/GenePageQuery.gql
+++ b/src/queries/GenePageQuery.gql
@@ -7,11 +7,9 @@ query GenePageQuery($geneId: String!) {
     end
     bioType
   }
-  studiesAndLeadVariantsForGene(geneId: $geneId) {
-    indexVariant {
-      rsId
-      id
-    }
+  studiesAndLeadVariantsForGeneByL2G(geneId: $geneId) {
+    pval
+    yProbaModel
     study {
       studyId
       traitReported
@@ -19,17 +17,22 @@ query GenePageQuery($geneId: String!) {
       pubDate
       pmid
       nInitial
-      nReplication
-      nCases
     }
-    pval
-    oddsRatio
-    oddsRatioCILower
-    oddsRatioCIUpper
-    beta
-    betaCILower
-    betaCIUpper
-    direction
+    variant {
+      rsId
+      id
+    }
+    odds{
+      oddsCI
+      oddsCILower
+      oddsCIUpper
+    }
+    beta{
+      betaCI
+      betaCILower
+      betaCIUpper
+      direction
+    }
   }
   colocalisationsForGene(geneId: $geneId) {
     leftVariant {

--- a/src/queries/StudyLocusPageQuery.gql
+++ b/src/queries/StudyLocusPageQuery.gql
@@ -29,7 +29,7 @@ query StudyLocusPageQuery(
       }
       yProbaModel
       yProbaDistance
-      yProbaInterlocus
+      # yProbaInterlocus
       yProbaInteraction
       yProbaMolecularQTL
       yProbaPathogenicity

--- a/src/queries/StudyLocusPageQuery.gql
+++ b/src/queries/StudyLocusPageQuery.gql
@@ -21,6 +21,22 @@ query StudyLocusPageQuery(
     pubJournal
     pmid
   }
+  studyLocus2GeneTable(studyId:$studyId variantId:$variantId){
+    rows{
+      gene{
+        symbol
+        id
+      }
+      yProbaModel
+      yProbaDistance
+      yProbaInterlocus
+      yProbaInteraction
+      yProbaMolecularQTL
+      yProbaPathogenicity
+      hasColoc
+      distanceToLocus
+    }
+  }
   gwasColocalisation(studyId: $studyId, variantId: $variantId) {
     indexVariant {
       id

--- a/src/queries/StudyLocusPageQuery.gql
+++ b/src/queries/StudyLocusPageQuery.gql
@@ -117,6 +117,7 @@ query StudyLocusPageQuery(
   #     h4
   #     log2h4h3
   #   }
+  
   pageCredibleSet: gwasCredibleSet(studyId: $studyId, variantId: $variantId) {
     tagVariant {
       id
@@ -132,6 +133,25 @@ query StudyLocusPageQuery(
     is95
     is99
   }
+
+  pageSummary: studyAndLeadVariantInfo(studyId: $studyId, variantId: $variantId) {
+    indexVariant {
+      rsId
+    }
+    study {
+      traitReported
+    }
+    pvalMantissa
+    pvalExponent
+    oddsRatio
+    oddsRatioCILower
+    oddsRatioCIUpper
+    beta
+    direction
+    betaCILower
+    betaCIUpper
+  }
+
   genes(chromosome: $chromosome, start: $start, end: $end) {
     id
     symbol

--- a/src/queries/StudyPageQuery.gql
+++ b/src/queries/StudyPageQuery.gql
@@ -43,6 +43,13 @@ query StudyPageQuery($studyId: String!) {
           symbol
         }
       }
+      bestLocus2Genes{
+        score
+        gene {
+          id
+          symbol
+        }
+      }
     }
   }
 }

--- a/src/queries/StudyPageQuery.gql
+++ b/src/queries/StudyPageQuery.gql
@@ -18,6 +18,11 @@ query StudyPageQuery($studyId: String!) {
         rsId
         chromosome
         position
+        nearestCodingGene{
+          id
+          symbol
+        }
+        nearestCodingGeneDistance
       }
       pval
       credibleSetSize


### PR DESCRIPTION
This PR updates or adds the following 3 tables:
manhattan table on study page; issue https://github.com/opentargets/genetics/issues/411
associated studies table on gene page; issue https://github.com/opentargets/genetics/issues/413
new table on study-locus page; issue https://github.com/opentargets/genetics/issues/414

This is still a *work in progress*.
Will need to review the changes with the genetics team prior to code review.