### PR TITLE
Update Node in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # and the 2nd stage sets up the latest nginx:alpine.
 
 # ============================== node/build section =====================================================
-FROM node:8.15-alpine as build_section
+FROM node:14.17-alpine as build_section
 
 ARG REACT_APP_GRAPHQL_API_URL=https://genetics-api.opentargets.io
 ARG REACT_APP_PLATFORM_URL=https://targetvalidation.org


### PR DESCRIPTION
This PR updates Node from v8.15 to v14.17 in the Docker image to match the requirements of the recent release(s). I tested it locally and didn't notice any issues.