### PR TITLE
[Variant] fix: remove id from genesForVariantSchema/intervals

### DIFF
--- a/src/queries/VariantPageQuery.gql
+++ b/src/queries/VariantPageQuery.gql
@@ -45,7 +45,6 @@ query VariantPageQuery($variantId: String!) {
       }
     }
     intervals {
-      id
       sourceId
       sourceLabel
       sourceDescriptionOverview


### PR DESCRIPTION
One id is duplicated in genesForVariantSchema -> intervals (`pchic`), this cause that the `@apollo/client` component response with duplicated elements for **javierre2016** and **jung2019** 

The front-end use `sourceId` field to build the AssociatedGenes table so it is safe just to remove the id from the query

Deploy preview: https://deploy-preview-180--genetics-app.netlify.app/variant/1_154453788_C_T
reference: https://www.apollographql.com/docs/react/caching/cache-interaction/

![Screenshot 2021-11-19 at 11 39 25](https://user-images.githubusercontent.com/2972633/142617008-b6a4d47c-151b-4273-bae0-6e128d7bfc45.png)
