### PR TITLE
[Search] Put back numAssocLoci on search options

### DIFF
--- a/src/components/Search/SearchOption.js
+++ b/src/components/Search/SearchOption.js
@@ -27,19 +27,19 @@ const Option = ({ data }) => {
             <React.Fragment>
               {data.pubJournal ? <em>{data.pubJournal} </em> : null}N Study:{' '}
               {commaSeparate(data.nInitial)}
-              {data.hasSumstats ? (
-                <span style={{ float: 'right' }}>
-                  {data.hasSumstats ? (
-                    <Chip
-                      style={{
-                        height: '16px',
-                        fontSize: '0.7rem',
-                        marginRight: '16px',
-                      }}
-                      color="primary"
-                      label="summary statistics"
-                    />
-                  ) : null}
+              <span style={{ float: 'right' }}>
+                {data.hasSumstats ? (
+                  <Chip
+                    style={{
+                      height: '16px',
+                      fontSize: '0.7rem',
+                      marginRight: '16px',
+                    }}
+                    color="primary"
+                    label="summary statistics"
+                  />
+                ) : null}
+                {data.numAssocLoci ? (
                   <span
                     style={{
                       minWidth: '100px',
@@ -49,8 +49,8 @@ const Option = ({ data }) => {
                   >
                     <strong>{data.numAssocLoci} associated loci</strong>
                   </span>
-                </span>
-              ) : null}
+                ) : null}
+              </span>
             </React.Fragment>
           }
         />


### PR DESCRIPTION
Deploy preview: https://deploy-preview-181--genetics-app.netlify.app/
Bug, missing numAssocLoci on search options:
<img width="896" alt="Screenshot 2021-11-18 at 16 24 28" src="https://user-images.githubusercontent.com/2972633/142639514-ce14956d-5909-4cbb-9747-109ed7117f0a.png">
