### PR TITLE
[Variant page] Use HTTPS for linkout to Ensembl

### DIFF
--- a/src/pages/VariantPage/Header.js
+++ b/src/pages/VariantPage/Header.js
@@ -25,7 +25,7 @@ const VariantHeader = ({ loading, data }) => {
           />
           <ExternalLink
             title="gnomAD"
-            url={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${rsId}`}
+            url={`https://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${rsId}`}
             id={rsId}
           />
         </>


### PR DESCRIPTION
I noticed that the linkout to Ensembl from the variant page uses HTTP even though HTTPS is available.

* Example variant page: https://genetics.opentargets.org/variant/1_154453788_C_T
* Example current linkout URL: http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=rs4129267
* Example proposed linkout URL: https://www.ensembl.org/Homo_sapiens/Variation/Explore?v=rs4129267

I know that the certificate for the Ensembl API can sometimes causes issues when querying the API (e.g. see https://github.com/Ensembl/ensembl-rest/issues/427), but I've never had any problem using HTTPS for Ensembl URLs in a web browser.