### PR TITLE
Update footer to show correct partners and help links

### DIFF
--- a/src/components/EmailLink.js
+++ b/src/components/EmailLink.js
@@ -8,7 +8,6 @@ const styles = theme => ({
   emailLink: {
     display: 'flex',
     alignItems: 'center',
-    fontSize: '0.8rem',
     textDecoration: 'none',
     outline: 'none',
     color: 'inherit',
@@ -33,7 +32,7 @@ const EmailLink = ({
     {iconClasses && (
       <Icon className={classNames(iconClasses, classes.iconPadding)} />
     )}
-    {contentRect.bounds.width < 225 ? 'Email support' : label}
+    {contentRect.bounds.width < 225 ? 'helpdesk@opentargets.org' : label}
   </a>
 );
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -69,9 +69,14 @@ export const externalLinks = {
       url: 'https://genetics-docs.opentargets.org',
     },
     {
-      label: 'Ask a question',
-      iconClasses: 'fa fa-question-circle',
+      label: 'Community',
+      iconClasses: 'fab fa-discourse',
       url: 'https://community.opentargets.org/',
+    },
+    {
+      label: 'helpdesk@opentargets.org',
+      iconClasses: 'fa fa-envelope',
+      url: 'mailto:helpdesk@opentargets.org',
     },
   ],
   social: [

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,12 @@ export const mainMenuItems = [
     url: 'https://genetics-docs.opentargets.org',
     external: true,
   },
+  // Data downloads
+  {
+    name: 'Data downloads',
+    url: 'https://genetics-docs.opentargets.org/data-access/data-download',
+    external: true,
+  },
   // API
   {
     name: 'API',

--- a/src/ot-ui-components/components/EmailLink.js
+++ b/src/ot-ui-components/components/EmailLink.js
@@ -8,7 +8,6 @@ const styles = theme => ({
   emailLink: {
     display: 'flex',
     alignItems: 'center',
-    fontSize: '0.8rem',
     textDecoration: 'none',
     outline: 'none',
     color: 'inherit',
@@ -33,7 +32,7 @@ const EmailLink = ({
     {iconClasses && (
       <Icon className={classNames(iconClasses, classes.iconPadding)} />
     )}
-    {contentRect.bounds.width < 225 ? 'Email support' : label}
+    {contentRect.bounds.width < 225 ? 'helpdesk@opentargets.org' : label}
   </a>
 );
 


### PR DESCRIPTION
This PR adds an envelope icon and help desk email to the footer component. It also adds a link to the data downloads documentation in the hamburger menu.