### PR TITLE
Format numbers to 4 decimal points; opentargets/genetics#537

### DIFF
--- a/src/ot-ui-components/helpers/significantFigures.js
+++ b/src/ot-ui-components/helpers/significantFigures.js
@@ -1,5 +1,5 @@
 import { format } from 'd3-format';
 
-const significantFigures = format('.2g');
+const significantFigures = format('.4g');
 
 export default significantFigures;


### PR DESCRIPTION
This PR formats all floats seen in Open Targets Genetics to a precision with 4 decimal points.

Deploy preview --> https://deploy-preview-206--genetics-app.netlify.app/study-locus/GCST90038599/7_100691506_A_ATTTTTTT